### PR TITLE
Reject path-traversal entry names on extract

### DIFF
--- a/src/pakfile.c
+++ b/src/pakfile.c
@@ -35,6 +35,7 @@ static int delete_entries(Pak_t *pak, Pakfileentry_t **entries, int num_entries)
 static int copy_between_paks(Pakfileentry_t *entry, FILE *ffd, FILE *tfd);
 static FILE *create_tmp_pakfile(void);
 static int in_array(Pakfileentry_t *entry, Pakfileentry_t **entries, int num_entries);
+static int is_unsafe_extract_path(const char *path);
 
 static int is_new = 0;
 static char cur_pakpath[OS_PATH_MAX];
@@ -455,6 +456,11 @@ void extract_files(Pak_t *pak, char *dest, char **paths, int path_count) {
             if (! matched) continue;
         }
 
+        if (is_unsafe_extract_path(current->filename)) {
+            error_exit("Refusing to extract '%s': entry name would escape destination",
+                       current->filename);
+        }
+
         /* + 2 one for trailing null and the / we concat between basedir and pakfile path */
         destfile = malloc(sizeof(char) * (strlen(dest) + strlen(current->filename) + 2));
 		*destfile = '\0';
@@ -625,6 +631,50 @@ void build_filename(char *basedir, char *filename, char *dest) {
     strcat(dest, basedir);
     strcat(dest, "/");
     strcat(dest, filename);
+}
+
+/* Validate a pak entry name before extracting. Pak format places no
+ * constraints on entry names beyond a 56-byte upper bound, so a malicious
+ * pak can name an entry "../../etc/passwd" or "C:\windows\foo" and silently
+ * write outside the -C destination on extract. Both POSIX and Windows
+ * targets are checked here, because pak archives are portable and a pak
+ * crafted on Windows could be unpacked on POSIX (or vice versa). */
+static int is_unsafe_extract_path(const char *path) {
+    const char *p, *seg;
+    size_t seg_len;
+
+    if (path == NULL || *path == '\0') {
+        return 1;
+    }
+
+    if (path[0] == '/' || path[0] == '\\') {
+        return 1;
+    }
+
+    /* Drive-letter prefix ("X:..."): on Windows, fopen honors this and
+     * would route the write to a different drive's CWD or root. Reject
+     * unconditionally — pak entries should never carry one. */
+    if (path[1] == ':') {
+        return 1;
+    }
+
+    /* Walk slash- or backslash-separated segments. Only an exact ".."
+     * segment is rejected; "..foo" or "foo.." are legal characters. */
+    seg = path;
+    for (p = path; ; p++) {
+        if (*p == '/' || *p == '\\' || *p == '\0') {
+            seg_len = (size_t)(p - seg);
+            if (seg_len == 2 && seg[0] == '.' && seg[1] == '.') {
+                return 1;
+            }
+            if (*p == '\0') {
+                break;
+            }
+            seg = p + 1;
+        }
+    }
+
+    return 0;
 }
 
 Pakfileentry_t *find_tail(Pak_t *pak) {

--- a/tests/pakka.bats
+++ b/tests/pakka.bats
@@ -17,6 +17,26 @@ PROJECT_ROOT="${BATS_TEST_DIRNAME}/.."
 PAKKA="${PROJECT_ROOT}/pakka"
 PAK0="${PROJECT_ROOT}/build/test/pak0.pak"
 
+# Build a minimal valid pak with a single directory entry of the given
+# name and a zero-length payload. Used by the path-traversal tests to
+# inject names that would never come from pakka's own pack path.
+# Layout: 12-byte header + 64-byte dir entry, no payload bytes.
+write_pak_one_entry() {
+    # NB: split `local` over two statements — `local a="$1" b="$2" c=${#b}`
+    # evaluates `${#b}` *before* b="$2" is processed, yielding zero.
+    local pakfile="$1" name="$2"
+    local pad=$((56 - ${#name}))
+    {
+        # PACK + diroffset=12 (LE) + dirlength=64 (LE)
+        printf 'PACK\014\000\000\000\100\000\000\000'
+        printf '%s' "$name"
+        dd if=/dev/zero bs=1 count="$pad" 2>/dev/null
+        # offset=76 (past directory; never read because we error first)
+        # length=0
+        printf '\114\000\000\000\000\000\000\000'
+    } > "$pakfile"
+}
+
 setup_file() {
     mkdir -p "$BATS_FILE_TMPDIR/extracted"
     "$PAKKA" -xf "$PAK0" -C "$BATS_FILE_TMPDIR/extracted" >/dev/null
@@ -226,4 +246,91 @@ EOF
     printf 'PACK\014\000\000\000\100\000\000\000' > "$BATS_TEST_TMPDIR/short_dir.pak"
     run "$PAKKA" -lf "$BATS_TEST_TMPDIR/short_dir.pak"
     [ "$status" -ne 0 ]
+}
+
+# Path-traversal hardening: a crafted pak can name an entry such that extract
+# would write outside the -C destination. Pak entry names are 56 bytes of
+# attacker-controlled data; pakka must reject traversal attempts on both
+# POSIX and Windows shapes (drive letters, UNC, mixed separators) since
+# paks are cross-platform.
+
+@test "extract: refuses '..' path traversal in POSIX-style entry name" {
+    write_pak_one_entry "$BATS_TEST_TMPDIR/evil.pak" '../etc/passwd'
+    mkdir -p "$BATS_TEST_TMPDIR/out"
+    run "$PAKKA" -xf "$BATS_TEST_TMPDIR/evil.pak" -C "$BATS_TEST_TMPDIR/out"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -q "Refusing to extract"
+    [ ! -e "$BATS_TEST_TMPDIR/etc" ]
+}
+
+@test "extract: refuses absolute POSIX path in entry name" {
+    write_pak_one_entry "$BATS_TEST_TMPDIR/evil.pak" '/etc/passwd'
+    mkdir -p "$BATS_TEST_TMPDIR/out"
+    run "$PAKKA" -xf "$BATS_TEST_TMPDIR/evil.pak" -C "$BATS_TEST_TMPDIR/out"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -q "Refusing to extract"
+}
+
+@test "extract: refuses '..' traversal using backslash separator" {
+    write_pak_one_entry "$BATS_TEST_TMPDIR/evil.pak" '..\windows\foo'
+    mkdir -p "$BATS_TEST_TMPDIR/out"
+    run "$PAKKA" -xf "$BATS_TEST_TMPDIR/evil.pak" -C "$BATS_TEST_TMPDIR/out"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -q "Refusing to extract"
+}
+
+@test "extract: refuses leading-backslash absolute path" {
+    write_pak_one_entry "$BATS_TEST_TMPDIR/evil.pak" '\windows\foo'
+    mkdir -p "$BATS_TEST_TMPDIR/out"
+    run "$PAKKA" -xf "$BATS_TEST_TMPDIR/evil.pak" -C "$BATS_TEST_TMPDIR/out"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -q "Refusing to extract"
+}
+
+@test "extract: refuses Windows drive-letter prefix" {
+    write_pak_one_entry "$BATS_TEST_TMPDIR/evil.pak" 'C:\windows\foo'
+    mkdir -p "$BATS_TEST_TMPDIR/out"
+    run "$PAKKA" -xf "$BATS_TEST_TMPDIR/evil.pak" -C "$BATS_TEST_TMPDIR/out"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -q "Refusing to extract"
+}
+
+@test "extract: refuses UNC \\\\server\\share path" {
+    write_pak_one_entry "$BATS_TEST_TMPDIR/evil.pak" '\\server\share\foo'
+    mkdir -p "$BATS_TEST_TMPDIR/out"
+    run "$PAKKA" -xf "$BATS_TEST_TMPDIR/evil.pak" -C "$BATS_TEST_TMPDIR/out"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -q "Refusing to extract"
+}
+
+@test "extract: refuses empty (all-NUL) entry name" {
+    {
+        printf 'PACK\014\000\000\000\100\000\000\000'
+        dd if=/dev/zero bs=1 count=56 2>/dev/null
+        printf '\114\000\000\000\000\000\000\000'
+    } > "$BATS_TEST_TMPDIR/evil.pak"
+    mkdir -p "$BATS_TEST_TMPDIR/out"
+    run "$PAKKA" -xf "$BATS_TEST_TMPDIR/evil.pak" -C "$BATS_TEST_TMPDIR/out"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -q "Refusing to extract"
+}
+
+@test "extract: legitimate '..' substring in name (foo..bar) still extracts" {
+    # Sanity: only an exact ".." path component is unsafe. Substring
+    # patterns like "foo..bar" or "..foo" must continue to work, or
+    # we'd break legitimate filenames.
+    {
+        # Header: diroffset=17 (12-byte header + 5-byte payload), dirlength=64
+        printf 'PACK\021\000\000\000\100\000\000\000'
+        printf 'hello'
+        printf 'foo..bar'
+        dd if=/dev/zero bs=1 count=$((56 - 8)) 2>/dev/null
+        # offset=12 (start of payload), length=5
+        printf '\014\000\000\000\005\000\000\000'
+    } > "$BATS_TEST_TMPDIR/legit.pak"
+
+    mkdir -p "$BATS_TEST_TMPDIR/out"
+    "$PAKKA" -xf "$BATS_TEST_TMPDIR/legit.pak" -C "$BATS_TEST_TMPDIR/out" >/dev/null
+    [ -f "$BATS_TEST_TMPDIR/out/foo..bar" ]
+    [ "$(cat "$BATS_TEST_TMPDIR/out/foo..bar")" = "hello" ]
 }


### PR DESCRIPTION
## Summary
- Pak entry names are 56 bytes of attacker-controlled data, and `extract_files` concatenated them verbatim onto the `-C` destination with no validation. A crafted pak with `../etc/passwd`, `/abs/path`, `C:\windows\foo`, `\\server\share\foo`, or `..\windows\foo` would write outside the destination.
- Adds an `is_unsafe_extract_path` check at the top of the `extract_files` loop. Rejects empty names, leading `/` or `\`, drive-letter prefix (`X:`), and exact `..` path components (slash- or backslash-separated). Substrings like `..foo` and `foo..bar` stay legal.
- Validation runs before any `mkdir`, `fread`, or `fopen`, so a malicious pak fails fast with no partial side effects.
- Covers both POSIX path conventions (`..`, `/`) and Windows ones (`\`, `X:`, UNC `\\host\share`), because paks are portable between platforms.

## Why both conventions, even on POSIX
Pak archives can be authored on either platform and unpacked on the other. A pak crafted on Windows can attack a Linux host, and vice versa — the Windows-style names are not theoretical noise.

## Test plan
- [x] `make test` — all 23 bats tests pass (15 existing + 8 new)
- [x] `make lint` — clang-tidy clean with `WarningsAsErrors: '*'`
- [x] New tests cover: `../etc/passwd`, `/etc/passwd`, `..\windows\foo`, `\windows\foo`, `C:\windows\foo`, `\\server\share\foo`, all-NUL entry name
- [x] Sanity: `foo..bar` (legal substring) still extracts to verify we didn't over-reject
- [x] Reviewer: confirm the validator order — check happens before `mkdir_r`, `fread`, and `fopen(destfile, "wb")` so a partial extraction can never leave files on disk