### PR TITLE
Support building under MSVC / Visual Studio

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,12 @@ jobs:
           tar xzf actionlint.tar.gz actionlint
       - run: ./actionlint -color .github/workflows/test.yml
       - uses: astral-sh/setup-uv@v8.1.0
+        with:
+          # Pakka is not a Python project; the default cache glob hunts
+          # for requirements.txt / pyproject.toml and warns that the
+          # cache will never invalidate. We only use uv to run zizmor
+          # once — caching buys nothing.
+          enable-cache: false
       - run: uvx zizmor==1.25.2 .github/workflows/test.yml
       - name: Install clang-tidy
         run: |
@@ -195,7 +201,9 @@ jobs:
   # doesn't apply here) and MSYS2 to provide bash + bats for running
   # the existing test suite against the resulting pakka.exe.
   windows-msvc-x86_64:
-    runs-on: windows-latest
+    # windows-latest is being redirected to this label by mid-June 2026
+    # per the runner banner; pinning explicitly avoids the noise.
+    runs-on: windows-2025-vs2026
     defaults:
       run:
         shell: msys2 {0}
@@ -207,7 +215,11 @@ jobs:
         with:
           path: build/test/quakesw.tar.gz
           key: quakesw-${{ hashFiles('Makefile') }}
-      - uses: ilammy/msvc-dev-cmd@v1
+      # Fork of ilammy/msvc-dev-cmd that's actively maintained and
+      # runs on Node 24 (ilammy's v1.13.0 is still on Node 20).
+      - uses: TheMrMilchmann/setup-msvc-dev@v4
+        with:
+          arch: x64
       - uses: msys2/setup-msys2@v2
         with:
           # setup-msys2 caches its install dir by default (keyed on the

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -213,12 +213,18 @@ jobs:
           update: true
           install: >-
             bash
-            bats
             coreutils
             curl
+            git
             openssl
             tar
             make
+      # MSYS2 has no bats package; install from upstream. /usr/local/bin
+      # is on the default MSYS2 PATH so no extra wiring needed.
+      - name: Install bats-core
+        run: |
+          git clone --depth 1 --branch v1.13.0 https://github.com/bats-core/bats-core.git /tmp/bats-core
+          /tmp/bats-core/install.sh /usr/local
       # CMake/Ninja are preinstalled on the windows-latest image but live
       # outside the MSYS2 environment; expose them via a cmd shell that
       # has both MSVC and the runner PATH set up.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,7 +210,11 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1
       - uses: msys2/setup-msys2@v2
         with:
-          update: true
+          # setup-msys2 caches its install dir by default (keyed on the
+          # install list). `update: false` keeps `pacman -Syu` from
+          # firing on every run — the windows-latest MSYS2 base already
+          # ships current versions of everything we need.
+          update: false
           install: >-
             bash
             coreutils

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -241,8 +241,13 @@ jobs:
       - name: Fetch + verify Quake fixture
         run: make fixture
       - name: Run bats tests against pakka.exe
-        # Relative path so MSYS2 bash resolves it against $PWD instead
-        # of choking on the mixed-separator $GITHUB_WORKSPACE form.
-        env:
-          PAKKA: ./build/cmake/pakka.exe
-        run: bats tests/
+        # Resolve PAKKA to an MSYS2-style absolute path: relative paths
+        # can break inside bats's setup_file (bats may chdir into a temp
+        # dir before invoking it), and $GITHUB_WORKSPACE is Windows-shape
+        # which trips MSYS2 bash path resolution. $PWD inside this step
+        # is already the MSYS2 form of the workspace.
+        run: |
+          ls -la build/cmake/ || true
+          test -x build/cmake/pakka.exe
+          export PAKKA="$PWD/build/cmake/pakka.exe"
+          bats tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -190,3 +190,49 @@ jobs:
           sync: rsync
           prepare: pkg_add -I gmake curl bats
           run: gmake test
+
+  # Windows / MSVC build. Uses CMake to drive cl.exe (the Unix Makefile
+  # doesn't apply here) and MSYS2 to provide bash + bats for running
+  # the existing test suite against the resulting pakka.exe.
+  windows-msvc-x86_64:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/cache@v5
+        with:
+          path: build/test/quakesw.tar.gz
+          key: quakesw-${{ hashFiles('Makefile') }}
+      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          install: >-
+            bash
+            bats
+            coreutils
+            curl
+            openssl
+            tar
+            make
+      # CMake/Ninja are preinstalled on the windows-latest image but live
+      # outside the MSYS2 environment; expose them via a cmd shell that
+      # has both MSVC and the runner PATH set up.
+      - name: Configure (CMake / Ninja / MSVC)
+        shell: pwsh
+        run: cmake -B build/cmake -G Ninja .
+      - name: Build
+        shell: pwsh
+        run: cmake --build build/cmake
+      - name: Fetch + verify Quake fixture
+        run: make fixture
+      - name: Run bats tests against pakka.exe
+        # Relative path so MSYS2 bash resolves it against $PWD instead
+        # of choking on the mixed-separator $GITHUB_WORKSPACE form.
+        env:
+          PAKKA: ./build/cmake/pakka.exe
+        run: bats tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -219,6 +219,7 @@ jobs:
             bash
             coreutils
             curl
+            diffutils
             git
             openssl
             tar

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,64 @@
+# CMakeLists.txt — Windows / MSVC build entry point.
+#
+# This is additive: the Unix build stays on the hand-written Makefile.
+# CMake exists so cl.exe (and any IDE / build generator that consumes
+# CMake) can produce pakka.exe on Windows. The two builds share src/
+# and src/win/ but nothing else.
+
+cmake_minimum_required(VERSION 3.15)
+project(pakka VERSION 1.1.0 LANGUAGES C)
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+string(TIMESTAMP PAKKA_BUILD_DATE "%b %d, %Y")
+
+set(PAKKA_SOURCES
+    src/common.c
+    src/compat.c
+    src/debug.c
+    src/filesystem.c
+    src/main.c
+    src/pakfile.c
+)
+
+if(WIN32)
+    # tronkko/dirent is header-only (dirent.h) so only wingetopt has a .c.
+    list(APPEND PAKKA_SOURCES src/win/wingetopt/getopt.c)
+endif()
+
+add_executable(pakka ${PAKKA_SOURCES})
+
+target_include_directories(pakka PRIVATE src)
+if(WIN32)
+    # wingetopt's getopt.c uses #include <getopt.h>, so its directory
+    # must be on the angle-include search path. dirent likewise.
+    target_include_directories(pakka PRIVATE
+        src/win/wingetopt
+        src/win/dirent
+    )
+endif()
+
+target_compile_definitions(pakka PRIVATE
+    "APP_NAME=\"Pakka\""
+    "VERSION=\"${PROJECT_VERSION}\""
+    "BUILD_DATE=\"${PAKKA_BUILD_DATE}\""
+    _DEBUG=1
+)
+
+if(MSVC)
+    # Warnings-as-errors mirrors the .clang-tidy WarningsAsErrors: '*'
+    # policy on the Unix side. C4996 ("'fopen': This function may be
+    # unsafe...") is silenced because pakka's input is constrained
+    # and the _s variants would buy us nothing.
+    target_compile_options(pakka PRIVATE /W4 /WX)
+    target_compile_definitions(pakka PRIVATE
+        _CRT_SECURE_NO_WARNINGS
+        _CRT_NONSTDC_NO_WARNINGS
+    )
+else()
+    target_compile_options(pakka PRIVATE -Wall -pedantic)
+    # realpath() is gated on _XOPEN_SOURCE under glibc/musl. Matches Makefile.
+    target_compile_definitions(pakka PRIVATE _XOPEN_SOURCE=700)
+endif()

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ PAK0=$(TEST_DIR)/pak0.pak
 
 CLANG_TIDY ?= clang-tidy
 
-.PHONY: all clean test test-clean distclean lint verify-tarball
+.PHONY: all clean test test-clean distclean lint verify-tarball fixture
 
 all: $(TARGET)
 
@@ -70,6 +70,11 @@ verify-tarball: $(QUAKE_TARBALL)
 $(PAK0): verify-tarball
 	@cd $(TEST_DIR) && tar xzf quakesw.tar.gz
 	@cp $(TEST_DIR)/id1/pak0.pak $(PAK0)
+
+# Download + SHA-verify pak0.pak only. Useful for CI configurations that
+# build pakka through a non-Make path (e.g. CMake/MSVC on Windows) but
+# still want to drive the bats suite against the canonical fixture.
+fixture: $(PAK0)
 
 test: $(TARGET) $(PAK0)
 	bats tests/

--- a/src/common.h
+++ b/src/common.h
@@ -3,9 +3,8 @@
 #include <stdint.h>
 #include <inttypes.h>
 #include <string.h>
-#include <unistd.h>
-#include <limits.h>
 
+#include "compat.h"
 #include "filesystem.h"
 
 #define OS_PATH_MAX PATH_MAX

--- a/src/compat.c
+++ b/src/compat.c
@@ -1,0 +1,128 @@
+#include "compat.h"
+
+#ifdef _WIN32
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+char *compat_realpath(const char *path, char *resolved) {
+    return _fullpath(resolved, path, _MAX_PATH);
+}
+
+char *compat_getcwd(char *buf, size_t size) {
+    return _getcwd(buf, (int)size);
+}
+
+FILE *compat_mkstemp_open(const char *basename_template,
+                          char *out_path, size_t out_path_size) {
+    DWORD len = GetTempPathA((DWORD)out_path_size, out_path);
+    if (len == 0 || len + strlen(basename_template) + 1 > out_path_size) {
+        return NULL;
+    }
+    strcat(out_path, basename_template);
+    if (_mktemp_s(out_path, out_path_size) != 0) {
+        return NULL;
+    }
+    return fopen(out_path, "wb");
+}
+
+char *compat_dirname(char *path) {
+    char *slash, *backslash, *last;
+    size_t len;
+
+    if (path == NULL || *path == '\0') {
+        return ".";
+    }
+
+    /* POSIX dirname strips trailing separators first: dirname("a/") == "."
+     * but dirname("a/b/") == "a". Apply the same rule for both / and \. */
+    len = strlen(path);
+    while (len > 1 && (path[len - 1] == '/' || path[len - 1] == '\\')) {
+        path[--len] = '\0';
+    }
+
+    slash = strrchr(path, '/');
+    backslash = strrchr(path, '\\');
+    /* Pointer comparison between unrelated pointers is implementation-
+     * defined; avoid it by picking by NULL-presence first. */
+    if (slash == NULL) {
+        last = backslash;
+    } else if (backslash == NULL) {
+        last = slash;
+    } else {
+        last = (slash > backslash) ? slash : backslash;
+    }
+
+    if (last == NULL) {
+        return ".";
+    }
+    if (last == path) {
+        last[1] = '\0';
+    } else {
+        *last = '\0';
+    }
+    return path;
+}
+
+int compat_mkdir(const char *path, int mode) {
+    (void)mode;
+    return _mkdir(path);
+}
+
+char *compat_strdup(const char *s) {
+    return _strdup(s);
+}
+
+int compat_rename_replace(const char *src, const char *dst) {
+    return MoveFileExA(src, dst, MOVEFILE_REPLACE_EXISTING) ? 0 : -1;
+}
+
+#else
+
+#include <fcntl.h>
+
+char *compat_realpath(const char *path, char *resolved) {
+    return realpath(path, resolved);
+}
+
+char *compat_getcwd(char *buf, size_t size) {
+    return getcwd(buf, size);
+}
+
+FILE *compat_mkstemp_open(const char *basename_template,
+                          char *out_path, size_t out_path_size) {
+    FILE *fp;
+    int n, fd;
+
+    n = snprintf(out_path, out_path_size, "/tmp/%s", basename_template);
+    if (n < 0 || (size_t)n >= out_path_size) {
+        return NULL;
+    }
+    if ((fd = mkstemp(out_path)) < 0) {
+        return NULL;
+    }
+    if ((fp = fdopen(fd, "wb")) == NULL) {
+        close(fd);
+        unlink(out_path);
+        return NULL;
+    }
+    return fp;
+}
+
+char *compat_dirname(char *path) {
+    return dirname(path);
+}
+
+int compat_mkdir(const char *path, int mode) {
+    return mkdir(path, (mode_t)mode);
+}
+
+char *compat_strdup(const char *s) {
+    return strdup(s);
+}
+
+int compat_rename_replace(const char *src, const char *dst) {
+    return rename(src, dst);
+}
+
+#endif

--- a/src/compat.h
+++ b/src/compat.h
@@ -1,0 +1,65 @@
+#ifndef PAKKA_COMPAT_H
+#define PAKKA_COMPAT_H
+
+/* Bridges POSIX calls used elsewhere in pakka to their Win32 equivalents
+ * under cl.exe. On POSIX builds, every compat_* function is a thin
+ * forwarding wrapper; on Windows builds it routes to _fullpath, _mkdir,
+ * GetTempPathA, MoveFileExA, etc. The point is that the rest of the
+ * codebase only ever names POSIX (or pakka-internal) primitives. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#ifdef _WIN32
+  #include <direct.h>
+  #include <io.h>
+  #include "win/wingetopt/getopt.h"
+  #include "win/dirent/dirent.h"
+
+  /* MSVC's POSIX-named CRT entry points carry a leading underscore.
+   * dirent.h above defines PATH_MAX/NAME_MAX from MAX_PATH if absent. */
+
+  /* UCRT's <sys/stat.h> defines S_ISREG/S_ISDIR, but the SDK headers
+   * older toolsets bundle don't — guard defensively. */
+  #ifndef S_ISREG
+    #define S_ISREG(m) (((m) & _S_IFMT) == _S_IFREG)
+  #endif
+  #ifndef S_ISDIR
+    #define S_ISDIR(m) (((m) & _S_IFMT) == _S_IFDIR)
+  #endif
+#else
+  #include <unistd.h>
+  #include <libgen.h>
+  #include <dirent.h>
+  #include <limits.h>
+#endif
+
+#define PATH_SEPARATOR "/"
+
+char *compat_realpath(const char *path, char *resolved);
+char *compat_getcwd(char *buf, size_t size);
+
+/* Open a fresh temp file in binary write mode and write the resolved
+ * path into out_path (capacity out_path_size). The basename suffix
+ * must contain "XXXXXX" for mkstemp/_mktemp_s substitution.
+ * On POSIX, files are created under /tmp/; on Windows, under the
+ * directory returned by GetTempPathA. Returns NULL on failure. */
+FILE *compat_mkstemp_open(const char *basename_template,
+                          char *out_path, size_t out_path_size);
+
+/* Returns the directory part of path. May mutate path in place
+ * (POSIX dirname() contract). Callers must pass a throwaway copy. */
+char *compat_dirname(char *path);
+
+int   compat_mkdir(const char *path, int mode);
+char *compat_strdup(const char *s);
+
+/* Rename src→dst, replacing dst if it exists. Returns 0 on success
+ * (POSIX rename convention), -1 on failure. Callers MUST close every
+ * open FILE* on dst before calling: CRT fopen on Windows omits
+ * FILE_SHARE_DELETE, so an outstanding handle blocks the replace. */
+int compat_rename_replace(const char *src, const char *dst);
+
+#endif

--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -26,7 +26,7 @@ int mkdir_r(char *path) {
     while ((curpos = strchr(curpos, '/'))) {
         *curpos = '\0';
         if (stat(path, &sb) != 0) {
-            if (mkdir(path, mode)) {
+            if (compat_mkdir(path, mode)) {
                 fprintf(stderr, "Could not create directory '%s': %s\n", path, strerror(errno));
                 return -1;
             }
@@ -41,7 +41,7 @@ int mkdir_r(char *path) {
         }
     }
 
-    if (mkdir(path, mode)) {
+    if (compat_mkdir(path, mode)) {
         fprintf(stderr, "Could not create directory '%s': %s\n", path, strerror(errno));
         return -1;
     }

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -2,8 +2,8 @@
 #include <string.h>
 #include <stdlib.h>
 #include <errno.h>
-#include <libgen.h>
-#include <sys/stat.h>
+
+#include "compat.h"
 
 int file_exists(const char *dirname);
 int mkdir_r(char *path);

--- a/src/main.c
+++ b/src/main.c
@@ -74,11 +74,11 @@ void extract(Pak_t *pak, char *destination, char **paths, int path_count) {
     char *realdest = malloc(sizeof(char) * OS_PATH_MAX);
 
     if (destination != NULL) {
-        if (realpath(destination, realdest) == NULL) {
+        if (compat_realpath(destination, realdest) == NULL) {
            error_exit("Cannot open destination path '%s'", destination);
         }
     } else {
-        if (getcwd(realdest, OS_PATH_MAX) == NULL) {
+        if (compat_getcwd(realdest, OS_PATH_MAX) == NULL) {
             error_exit("Cannot get current working directory");
         }
     }

--- a/src/pakfile.c
+++ b/src/pakfile.c
@@ -1,5 +1,4 @@
 #include "common.h"
-#include "dirent.h"
 
 /* UTF-8 box-drawing sequences for --tree output. Encoded as octal escapes
  * so the source file's text encoding doesn't change the emitted bytes. */
@@ -40,14 +39,15 @@ static int is_unsafe_extract_path(const char *path);
 static int is_new = 0;
 static char cur_pakpath[OS_PATH_MAX];
 static char new_pakpath[OS_PATH_MAX];
-static char tmp_pakpath[L_tmpnam];
+/* L_tmpnam on MSVC is 20 bytes — not enough for "C:\Users\...\Temp\pakkaXXXXXX". */
+static char tmp_pakpath[OS_PATH_MAX];
 static FILE *fp;
 
 Pak_t *open_pakfile(const char *pakpath) {
     strcpy(cur_pakpath, pakpath);
     Pak_t *pak = calloc(sizeof(Pak_t), 1);
 
-    if (! (fp = fopen(pakpath, "r+"))) {
+    if (! (fp = fopen(pakpath, "r+b"))) {
         error_exit("Cannot open %s", pakpath);
     }
 
@@ -62,21 +62,14 @@ Pak_t *create_pakfile(const char *pakpath) {
     struct stat sb;
 
     is_new = 1;
-    strcpy(tmp_pakpath, "/tmp/pakkaXXXXXX");
     strcpy(new_pakpath, pakpath);
 
     if (stat(pakpath, &sb) == 0) {
         error_exit("File already exists at destination %s", pakpath);
     }
 
-    int fd;
-    if ((fd = mkstemp(tmp_pakpath)) == -1) {
+    if (! (fp = compat_mkstemp_open("pakkaXXXXXX", tmp_pakpath, sizeof(tmp_pakpath)))) {
         error_exit("Cannot create temp pak file");
-    }
-
-    if (! (fp = fdopen(fd, "w"))) {
-        close(fd);
-        error_exit("Cannot open %s", tmp_pakpath);
     }
 
     init_pak_header(pak);
@@ -96,13 +89,20 @@ int close_pakfile(Pak_t *pak) {
 
     free(pak);
 
+    /* fclose BEFORE rename: CRT fopen on Windows does not request
+     * FILE_SHARE_DELETE, so MoveFileEx would otherwise be blocked by
+     * the still-open handle. delete_entries may have already closed
+     * fp on its own (it sets fp = NULL), so tolerate that. */
+    if (fp != NULL) {
+        fclose(fp);
+        fp = NULL;
+    }
+
     if (is_new) {
-        if (rename(tmp_pakpath, new_pakpath) == -1) {
+        if (compat_rename_replace(tmp_pakpath, new_pakpath) != 0) {
             error_exit("Could not rename tmp pak %s to final pak %s", tmp_pakpath, new_pakpath);
         }
     }
-
-    fclose(fp);
 
     return 0;
 }
@@ -206,7 +206,7 @@ void insert_tree_path(Paktreenode_t *root, const char *path,
         return;
     }
 
-    path_copy = strdup(path);
+    path_copy = compat_strdup(path);
     component = strtok(path_copy, "/");
 
     while (component != NULL) {
@@ -346,7 +346,7 @@ int add_file(Pak_t *pak, char *path) {
 
     printf("Adding %s to pak\n", path);
     
-    if (! (tfd = fopen(path, "r"))) {
+    if (! (tfd = fopen(path, "rb"))) {
         error_exit("Cannot open %s", path);
     }
 
@@ -468,8 +468,8 @@ void extract_files(Pak_t *pak, char *dest, char **paths, int path_count) {
 
         /* POSIX dirname() may modify its argument and/or return a static buffer
          * that subsequent calls overwrite. Pass it a throwaway copy. */
-        destdir_copy = strdup(destfile);
-        destdir = dirname(destdir_copy);
+        destdir_copy = compat_strdup(destfile);
+        destdir = compat_dirname(destdir_copy);
 
         if (! (file_exists(destdir)) && (mkdir_r(destdir) != 0)) {
             error_exit("Cannot create directory %s", destdir);
@@ -482,7 +482,7 @@ void extract_files(Pak_t *pak, char *dest, char **paths, int path_count) {
         buffer = malloc(sizeof(unsigned char) * current->length);
         fread(buffer, current->length, 1, fp);
 
-        if (! (tfd = fopen(destfile, "w"))) {
+        if (! (tfd = fopen(destfile, "wb"))) {
             error_exit("Cannot open %s for writing", destfile);
         }
 
@@ -588,8 +588,15 @@ int delete_entries(Pak_t *pak, Pakfileentry_t *entries[], int num_entries) {
     fp = tempfp;
 
     fclose(tfd);
-    
-    if (rename(tmp_pakpath, cur_pakpath) == -1) {
+
+    /* Close the original pak before the rename. On Windows the open
+     * handle on cur_pakpath would block MoveFileEx; on POSIX this just
+     * ensures buffered data is flushed before we replace the file
+     * underneath ourselves. close_pakfile tolerates fp == NULL. */
+    fclose(fp);
+    fp = NULL;
+
+    if (compat_rename_replace(tmp_pakpath, cur_pakpath) != 0) {
         error_exit("Could not rename tmp pak %s to final pak %s", tmp_pakpath, new_pakpath);
     }
 
@@ -744,17 +751,9 @@ void write_pak_directory(Pak_t *pak) {
 
 FILE *create_tmp_pakfile(void) {
     FILE *tfd;
-    int fd;
 
-    strcpy(tmp_pakpath, "/tmp/pakkaXXXXXX");
-
-    if ((fd = mkstemp(tmp_pakpath)) == -1) {
+    if (! (tfd = compat_mkstemp_open("pakkaXXXXXX", tmp_pakpath, sizeof(tmp_pakpath)))) {
         error_exit("Cannot create temp pak file");
-    }
-
-    if (! (tfd = fdopen(fd, "w"))) {
-        close(fd);
-        error_exit("Cannot open %s", tmp_pakpath);
     }
 
     fseek(tfd, PAKFILE_HEADER_SIZE, SEEK_SET);

--- a/src/pakfile.c
+++ b/src/pakfile.c
@@ -125,13 +125,13 @@ void load_pakfile(Pak_t *pak) {
 void load_directory(Pak_t *pak) {
     Pakfileentry_t *current = NULL;
     Pakfileentry_t *last = NULL;
-    int i, entry_pos;
+    uint32_t i, entry_pos;
 
     if (pak->num_entries > 0) {
         for (i = 1; i <= pak->num_entries; i++) {
-            entry_pos = pak->diroffset + pak->dirlength 
+            entry_pos = pak->diroffset + pak->dirlength
                 - (i * PAKFILE_DIR_ENTRY_SIZE);
-            fseek(fp, entry_pos, SEEK_SET);
+            fseek(fp, (long)entry_pos, SEEK_SET);
 
             current = calloc(1, sizeof(Pakfileentry_t));
             if (fread(current->filename, PAKFILE_PATH_MAX, 1, fp) != 1

--- a/src/win/VENDOR.md
+++ b/src/win/VENDOR.md
@@ -1,0 +1,26 @@
+# Vendored Windows polyfills
+
+These directories contain unmodified third-party sources used only when
+building under MSVC (`_WIN32`). On POSIX builds, nothing under `src/win/`
+is compiled. Each subdirectory retains its upstream `LICENSE` file.
+
+## wingetopt
+
+- Upstream: <https://github.com/alex85k/wingetopt>
+- Pinned at: tag `v1.00` (commit `effe6e2`, 2021-10-30)
+- License: ISC-style (MIT-compatible) — see `wingetopt/LICENSE`
+- Provides: `getopt()` for `cl.exe`, which has no `<unistd.h>`.
+
+## dirent
+
+- Upstream: <https://github.com/tronkko/dirent>
+- Pinned at: tag `1.26` (commit `31db647`, 2025-07-15)
+- License: MIT — see `dirent/LICENSE`
+- Provides: `<dirent.h>` polyfill over `FindFirstFile`/`FindNextFile` for
+  the recursive-add path in `pakfile.c`.
+
+## Updating
+
+Bump by replacing the file contents and updating the tag/commit/date
+above. Do not edit the vendored files in place — patches against the
+upstreams are out of scope here.

--- a/src/win/dirent/LICENSE
+++ b/src/win/dirent/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 1998-2019 Toni Ronkko
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/win/dirent/README.md
+++ b/src/win/dirent/README.md
@@ -1,0 +1,240 @@
+# Dirent 🐬
+
+Dirent a Linux/UNIX programming interface for retrieving information about
+files and directories.  This project provides a compatible programming
+interface for Microsoft Visual Studio compiler and Microsoft Windows operating
+system.  Using this interface, your C or C++ application can scan files and
+directories on Microsoft Windows and Linux/UNIX!
+
+Learn more about Dirent from the UNIX specification on
+[opengroup.org](https://pubs.opengroup.org/onlinepubs/7908799/xsh/dirent.h.html)!
+
+
+# Requirements 🔥
+
+In order to build unit tests and example programs, you will need:
+
+- [Microsoft Visual Studio](https://visualstudio.microsoft.com/) 2017 or later
+- [CMake](https://cmake.org/) version 3.13 or later
+
+
+# Installation ⚓
+
+Dirent can be installed with four alternative methods.  Method 1 is preferred
+for projects built without CMake, method 2 is preferred for projects where
+Dirent needs to be customized, method 3 is preferred for projects with
+multiple developers, and method 4 is preferred for organizations using Dirent
+in a number of projects.
+
+**Method 1**: Download the latest Dirent installation package from
+[GitHub](https://github.com/tronkko/dirent/releases) and unpack the
+installation file with 7-zip, for example.  Find the `include/dirent.h` file
+from the package, copy the file to a separate directory in your project, and
+add the directory to include path on Windows.  Having `dirent.h` in a separate
+directory allows your project to be compiled against native `dirent.h` on
+Linux/UNIX while substituting the functionality on Microsoft Windows.
+
+**Method 2**: Download the latest Dirent installation package from
+[GitHub](https://github.com/tronkko/dirent/releases) and unpack the whole
+package into your project's main directory.  Source Dirent from your own
+`CMakeLists.txt` file as
+
+    add_subdirectory(dirent)
+
+and link Dirent to executables as
+
+    add_executable(app app.c)
+    target_link_libraries(app dirent)
+
+**Method 3**: Edit your project's CMakeLists.txt file and load Dirent
+automatically from GitHub by adding the following code
+
+    include(FetchContent)
+    FetchContent_Declare(
+        dirent
+        URL https://github.com/tronkko/dirent/archive/refs/tags/1.26.zip
+    )
+    FetchContent_MakeAvailable(dirent)
+
+Link Dirent to executables as
+
+    add_executable(app app.c)
+    target_link_libraries(app dirent)
+
+**Method 4**: Download the latest Dirent installation package from
+[GitHub](https://github.com/tronkko/dirent/releases) and unpack files to a
+separate directory.  Cd to the directory and generate build files as
+
+    cmake -B build -D CMAKE_INSTALL_PREFIX="%USERPROFILE%\dist" .
+
+where `build` is a new directory for build files, `%USERPROFILE%\dist` is a
+directory for installable Dirent files and `.` is the root directory of the
+Dirent package containing this README.md file.  Open the generated
+`build/dirent.sln` file in Visual Studio and build the INSTALL target.  This
+needs to be done only once.
+
+In order to use Dirent in your own projects, update each project's
+CMakeLists.txt file by adding line
+
+    find_package(Dirent 1.26 REQUIRED)
+
+Link Dirent to executables as
+
+    add_executable(app app.c)
+    target_link_libraries(app dirent)
+
+If CMake cannot find Dirent, then use `-DCMAKE_INSTALL_PREFIX` option while
+configuring your own project as
+
+    cmake "-DCMAKE_INSTALL_PREFIX=%USERPROFILE%\dist" src
+
+where `%USERPROFILE%\dist` is the location of installable Dirent files and src
+is the location of your own source files.
+
+
+# Use UTF-8 File Names ⚡
+
+By default, file and directory names in the Dirent API are expressed in the
+current Windows codepage.  If you wish to use UTF-8 character encoding at all
+times, then replace the `main` function with `_main` function and convert
+wide-character arguments to UTF-8 strings as demonstrated in the snippet
+below.
+
+    #include <stdio.h>
+    #include <stdlib.h>
+    #include <string.h>
+    #include <locale.h>
+
+    /* This is your true main function */
+    static int
+    _main(int argc, char *argv[])
+    {
+        /* ... */
+        return EXIT_SUCCESS;
+    }
+
+    /* Convert arguments to UTF-8 */
+    #ifdef _MSC_VER
+    int
+    wmain(int argc, wchar_t *argv[])
+    {
+        /* Select UTF-8 locale */
+        setlocale(LC_ALL, ".utf8");
+        SetConsoleCP(CP_UTF8);
+        SetConsoleOutputCP(CP_UTF8);
+
+        /* Allocate memory for multi-byte argv table */
+        char **mbargv;
+        mbargv = (char**) malloc(argc * sizeof(char*));
+        if (!mbargv) {
+            puts("Out of memory");
+            exit(3);
+        }
+
+        /* Convert each argument to UTF-8 */
+        for (int i = 0; i < argc; i++) {
+            /* Compute the size of corresponding UTF-8 string */
+            size_t n;
+            wcstombs_s(&n, NULL, 0, argv[i], 0);
+
+            /* Allocate room for UTF-8 string */
+            mbargv[i] = (char*) malloc(n + 1);
+            if (!mbargv[i]) {
+                puts("Out of memory");
+                exit(3);
+            }
+
+            /* Convert ith argument to UTF-8 */
+            wcstombs_s(NULL, mbargv[i], n + 1, argv[i], n);
+        }
+
+        /* Pass UTF-8 arguments to the real main program */
+        int errorcode = _main(argc, mbargv);
+
+        /* Release UTF-8 arguments */
+        for (int i = 0; i < argc; i++) {
+            free(mbargv[i]);
+        }
+
+        /* Release the multi-byte argv table */
+        free(mbargv);
+        return errorcode;
+    }
+    #else
+    int
+    main(int argc, char *argv[])
+    {
+        return _main(argc, argv);
+    }
+    #endif
+
+For more information on UTF-8 support, please see setlocale in Visual Studio
+[C runtime library reference](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/setlocale-wsetlocale?view=msvc-160#utf-8-support).
+
+
+# Examples 🎓
+
+The source package contains the following example programs.
+
+Program  | Purpose
+-------- | -----------------------------------------------------------------
+[ls.c](examples/ls.c) | List files in a directory, e.g. `ls "c:\Program Files"`
+[dir.c](examples/dir.c) | List files in a directory, e.g. `dir "c:\Program Files"`
+[find.c](examples/find.c) | Find files in subdirectories, e.g. `find "c:\Program Files\CMake"`
+[updatedb.c](examples/updatedb.c) | Build database of files in a drive, e.g. `updatedb c:\`
+[locate.c](examples/locate.c) | Locate a file from database, e.g. `locate notepad`
+[scandir.c](examples/scandir.c) | Printed sorted list of file names in a directory, e.g. `scandir .`
+[du.c](examples/du.c) | Compute disk usage, e.g. `du "C:\Program Files"`
+[cat.c](examples/cat.c) | Print a text file to screen, e.g. `cat include/dirent.h`
+[stat.c](examples/stat.c) | Print file/directory permissions, e.g. `stat include/dirent.h`
+[extension\_lookup.cpp](examples/extension_lookup.cpp) | Search files with specific extension
+
+In order to build example programs, unpack the source package to your desktop,
+for example, open command prompt and cd to the root directory of the source
+package.  Generate build files as
+
+    cmake -B build .
+
+where `build` is a directory for build files and `.` is the root directory of
+the source package containing this README.md file.  Once CMake is finished,
+open Visual Studio, load the generated `dirent.sln` file from the build
+directory and build the whole solution.  Once the build completes, return to
+command prompt and cd to the Debug directory to run the example programs.  For
+example, run ls from the Debug directory as
+
+    cd Debug
+    .\ls .
+
+Examples are not built by default when Dirent is embedded into another
+project.  If you want to build examples, then add `-DDIRENT_EXAMPLES=ON`
+option to CMake command line when configuring your own project.
+
+
+# Testing 🔬
+
+This project contains unit tests.  In order to build and run the unit tests,
+first unpack the source package to your desktop, open command prompt and cd to
+the root directory of the source package.  Generate build files as
+
+    cmake -B build .
+
+where `build` is a directory for build files and `.` is the root directory of
+the Dirent package containing this README.md file.  Once CMake is finished,
+open Visual Studio, load the generated `dirent.sln` file from the build
+directory and build/rebuild solution named "check" in Visual Studio.
+
+Tests are not built by default when Dirent is embedded into another project.
+If you want to build tests, then add `-DDIRENT_TESTS=ON` option to CMake
+command line when configuring your own project.
+
+
+# Contributing 🐾
+
+We love to receive contributions from you.  See the
+[CONTRIBUTING](CONTRIBUTING.md) file for details.
+
+
+# Copying 📜
+
+Dirent may be freely distributed under the MIT license.  See the
+[LICENSE](LICENSE) file for details.

--- a/src/win/dirent/dirent.h
+++ b/src/win/dirent/dirent.h
@@ -1,0 +1,1207 @@
+/*
+ * Dirent interface for Microsoft Visual Studio
+ *
+ * Copyright (C) 1998-2019 Toni Ronkko
+ * This file is part of dirent.  Dirent may be freely distributed
+ * under the MIT license.  For all details and documentation, see
+ * https://github.com/tronkko/dirent
+ */
+#ifndef DIRENT_H
+#define DIRENT_H
+
+/* Hide warnings about unreferenced local functions */
+#if defined(__clang__)
+#	pragma clang diagnostic ignored "-Wunused-function"
+#elif defined(_MSC_VER)
+#	pragma warning(disable:4505)
+#elif defined(__GNUC__)
+#	pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+
+/*
+ * Include windows.h without Windows Sockets 1.1 to prevent conflicts with
+ * Windows Sockets 2.0.
+ */
+#ifndef WIN32_LEAN_AND_MEAN
+#	define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <wchar.h>
+#include <string.h>
+#include <stdlib.h>
+#include <malloc.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <ctype.h>
+
+/* Indicates that d_type field is available in dirent structure */
+#define _DIRENT_HAVE_D_TYPE
+
+/* Indicates that d_namlen field is available in dirent structure */
+#define _DIRENT_HAVE_D_NAMLEN
+
+/* Entries missing from MSVC 6.0 */
+#if !defined(FILE_ATTRIBUTE_DEVICE)
+#	define FILE_ATTRIBUTE_DEVICE 0x40
+#endif
+
+/* File type and permission flags for stat(), general mask */
+#if !defined(S_IFMT)
+#	define S_IFMT _S_IFMT
+#endif
+
+/*
+ * File types.  Be ware that macros S_IFLNK and S_ISLNK are only usable with
+ * dirent: the real stat() function call never returns these values!
+ */
+#if !defined(S_IFDIR)
+#	define S_IFDIR _S_IFDIR
+#endif
+#if !defined(S_IFCHR)
+#	define S_IFCHR _S_IFCHR
+#endif
+#if !defined(S_IFREG)
+#	define S_IFREG _S_IFREG
+#endif
+#if !defined(S_IFIFO)
+#	define S_IFIFO _S_IFIFO
+#endif
+#if !defined(S_IFBLK)
+#	define S_IFBLK 0x6000
+#endif
+#if !defined(S_IFLNK)
+#	define S_IFLNK 0xA000
+#endif
+#if !defined(S_IFSOCK)
+#	define S_IFSOCK 0xC000
+#endif
+#if !defined(S_IFWHT)
+#	define S_IFWHT 0xE000
+#endif
+
+/* Access permissions */
+#if !defined(S_IREAD)
+#	define S_IREAD _S_IREAD
+#endif
+#if !defined(S_IWRITE)
+#	define S_IWRITE _S_IWRITE
+#endif
+#if !defined(S_IEXEC)
+#	define S_IEXEC _S_IEXEC
+#endif
+
+/* User permissions */
+#if !defined(S_IRUSR)
+#	define S_IRUSR S_IREAD
+#endif
+#if !defined(S_IWUSR)
+#	define S_IWUSR S_IWRITE
+#endif
+#if !defined(S_IXUSR)
+#	define S_IXUSR _S_IEXEC
+#endif
+#if !defined(S_IRWXU)
+#	define S_IRWXU (S_IRUSR | S_IWUSR | S_IXUSR)
+#endif
+
+/* Group permissions */
+#if !defined(S_IRGRP)
+#	define S_IRGRP (S_IRUSR >> 3)
+#endif
+#if !defined(S_IWGRP)
+# define S_IWGRP (S_IWUSR >> 3)
+#endif
+#if !defined(S_IXGRP)
+# define S_IXGRP (S_IXUSR >> 3)
+#endif
+#if !defined(S_IRWXG)
+#	define S_IRWXG (S_IRGRP | S_IWGRP | S_IXGRP)
+#endif
+
+/* Others permission */
+#if !defined(S_IROTH)
+# define S_IROTH (S_IRGRP >> 3)
+#endif
+#if !defined(S_IWOTH)
+# define S_IWOTH (S_IWGRP >> 3)
+#endif
+#if !defined(S_IXOTH)
+# define S_IXOTH (S_IXGRP >> 3)
+#endif
+#if !defined(S_IRWXO)
+#	define S_IRWXO (S_IROTH | S_IWOTH | S_IXOTH)
+#endif
+
+/* Maximum length of file name */
+#if !defined(PATH_MAX)
+#	define PATH_MAX MAX_PATH
+#endif
+#if !defined(FILENAME_MAX)
+#	define FILENAME_MAX MAX_PATH
+#endif
+#if !defined(NAME_MAX)
+#	define NAME_MAX FILENAME_MAX
+#endif
+
+/* File type flags for d_type */
+#define DT_UNKNOWN 0
+#define DT_REG S_IFREG
+#define DT_DIR S_IFDIR
+#define DT_FIFO S_IFIFO
+#define DT_SOCK S_IFSOCK
+#define DT_CHR S_IFCHR
+#define DT_BLK S_IFBLK
+#define DT_LNK S_IFLNK
+#define DT_WHT S_IFWHT
+
+/* Macros for converting between st_mode and d_type */
+#define IFTODT(mode) ((mode) & S_IFMT)
+#define DTTOIF(type) (type)
+
+/*
+ * File type macros.  Note that block devices and sockets cannot be
+ * distinguished on Windows and macros such as S_ISBLK and S_ISSOCK are only
+ * defined for compatibility.  These macros should always return false on
+ * Windows.
+ */
+#if !defined(S_ISFIFO)
+#	define S_ISFIFO(mode) (((mode) & S_IFMT) == S_IFIFO)
+#endif
+#if !defined(S_ISDIR)
+#	define S_ISDIR(mode) (((mode) & S_IFMT) == S_IFDIR)
+#endif
+#if !defined(S_ISREG)
+#	define S_ISREG(mode) (((mode) & S_IFMT) == S_IFREG)
+#endif
+#if !defined(S_ISLNK)
+#	define S_ISLNK(mode) (((mode) & S_IFMT) == S_IFLNK)
+#endif
+#if !defined(S_ISSOCK)
+#	define S_ISSOCK(mode) (((mode) & S_IFMT) == S_IFSOCK)
+#endif
+#if !defined(S_ISCHR)
+#	define S_ISCHR(mode) (((mode) & S_IFMT) == S_IFCHR)
+#endif
+#if !defined(S_ISBLK)
+#	define S_ISBLK(mode) (((mode) & S_IFMT) == S_IFBLK)
+#endif
+#if !defined(S_ISWHT)
+#	define S_ISWHT(mode) (((mode) & S_IFMT) == S_IFWHT)
+#endif
+
+/* Return the exact length of the file name without zero terminator */
+#define _D_EXACT_NAMLEN(p) ((p)->d_namlen)
+
+/* Return the maximum size of a file name */
+#define _D_ALLOC_NAMLEN(p) ((PATH_MAX)+1)
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* Wide-character version */
+struct _wdirent {
+	/* Always zero */
+	long d_ino;
+
+	/* Position of next file in a directory stream */
+	long d_off;
+
+	/* Structure size */
+	unsigned short d_reclen;
+
+	/* Length of name without \0 */
+	size_t d_namlen;
+
+	/* File type */
+	int d_type;
+
+	/* File name */
+	wchar_t d_name[PATH_MAX+1];
+};
+typedef struct _wdirent _wdirent;
+
+struct _WDIR {
+	/* Current directory entry */
+	struct _wdirent ent;
+
+	/* Private file data */
+	WIN32_FIND_DATAW data;
+
+	/* True if data is valid */
+	int cached;
+
+	/* True if next entry is invalid */
+	int invalid;
+
+	/* Win32 search handle */
+	HANDLE handle;
+
+	/* Initial directory name */
+	wchar_t *patt;
+};
+typedef struct _WDIR _WDIR;
+
+/* Multi-byte character version */
+struct dirent {
+	/* Always zero */
+	long d_ino;
+
+	/* Position of next file in a directory stream */
+	long d_off;
+
+	/* Structure size */
+	unsigned short d_reclen;
+
+	/* Length of name without \0 */
+	size_t d_namlen;
+
+	/* File type */
+	int d_type;
+
+	/* File name */
+	char d_name[PATH_MAX+1];
+};
+typedef struct dirent dirent;
+
+struct DIR {
+	struct dirent ent;
+	struct _WDIR *wdirp;
+};
+typedef struct DIR DIR;
+
+
+/* Dirent functions */
+static DIR *opendir(const char *dirname);
+static _WDIR *_wopendir(const wchar_t *dirname);
+
+static struct dirent *readdir(DIR *dirp);
+static struct _wdirent *_wreaddir(_WDIR *dirp);
+
+static int readdir_r(
+	DIR *dirp, struct dirent *entry, struct dirent **result);
+static int _wreaddir_r(
+	_WDIR *dirp, struct _wdirent *entry, struct _wdirent **result);
+
+static int closedir(DIR *dirp);
+static int _wclosedir(_WDIR *dirp);
+
+static void rewinddir(DIR *dirp);
+static void _wrewinddir(_WDIR *dirp);
+
+static long telldir(DIR *dirp);
+static long _wtelldir(_WDIR *dirp);
+
+static void seekdir(DIR *dirp, long loc);
+static void _wseekdir(_WDIR *dirp, long loc);
+
+static int scandir(const char *dirname, struct dirent ***namelist,
+	int (*filter)(const struct dirent*),
+	int (*compare)(const struct dirent**, const struct dirent**));
+
+static int alphasort(const struct dirent **a, const struct dirent **b);
+
+static int versionsort(const struct dirent **a, const struct dirent **b);
+
+static int strverscmp(const char *a, const char *b);
+
+/* For compatibility with Symbian */
+#define wdirent _wdirent
+#define WDIR _WDIR
+#define wopendir _wopendir
+#define wreaddir _wreaddir
+#define wclosedir _wclosedir
+#define wrewinddir _wrewinddir
+#define wtelldir _wtelldir
+#define wseekdir _wseekdir
+
+/* Compatibility with older Microsoft compilers and non-Microsoft compilers */
+#if !defined(_MSC_VER) || _MSC_VER < 1400
+#	define wcstombs_s dirent_wcstombs_s
+#	define mbstowcs_s dirent_mbstowcs_s
+#endif
+
+/* Optimize dirent_set_errno() away on modern Microsoft compilers */
+#if defined(_MSC_VER) && _MSC_VER >= 1400
+#	define dirent_set_errno _set_errno
+#endif
+
+
+/* Internal utility functions */
+static WIN32_FIND_DATAW *dirent_first(_WDIR *dirp);
+static WIN32_FIND_DATAW *dirent_next(_WDIR *dirp);
+static long dirent_hash(WIN32_FIND_DATAW *datap);
+
+#if !defined(_MSC_VER) || _MSC_VER < 1400
+static int dirent_mbstowcs_s(
+	size_t *pReturnValue, wchar_t *wcstr, size_t sizeInWords,
+	const char *mbstr, size_t count);
+#endif
+
+#if !defined(_MSC_VER) || _MSC_VER < 1400
+static int dirent_wcstombs_s(
+	size_t *pReturnValue, char *mbstr, size_t sizeInBytes,
+	const wchar_t *wcstr, size_t count);
+#endif
+
+#if !defined(_MSC_VER) || _MSC_VER < 1400
+static void dirent_set_errno(int error);
+#endif
+
+
+/*
+ * Open directory stream DIRNAME for read and return a pointer to the
+ * internal working area that is used to retrieve individual directory
+ * entries.
+ */
+static _WDIR *
+_wopendir(const wchar_t *dirname)
+{
+	wchar_t *p;
+
+	/* Must have directory name */
+	if (dirname == NULL || dirname[0] == '\0') {
+		dirent_set_errno(ENOENT);
+		return NULL;
+	}
+
+	/* Allocate new _WDIR structure */
+	_WDIR *dirp = (_WDIR*) malloc(sizeof(struct _WDIR));
+	if (!dirp)
+		return NULL;
+
+	/* Reset _WDIR structure */
+	dirp->handle = INVALID_HANDLE_VALUE;
+	dirp->patt = NULL;
+	dirp->cached = 0;
+	dirp->invalid = 0;
+
+	/*
+	 * Compute the length of full path plus zero terminator
+	 *
+	 * Note that on WinRT there's no way to convert relative paths
+	 * into absolute paths, so just assume it is an absolute path.
+	 */
+#if !defined(WINAPI_FAMILY_PARTITION) || WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+	/* Desktop */
+	DWORD n = GetFullPathNameW(dirname, 0, NULL, NULL);
+#else
+	/* WinRT */
+	size_t n = wcslen(dirname);
+#endif
+
+	/* Allocate room for absolute directory name and search pattern */
+	dirp->patt = (wchar_t*) malloc(sizeof(wchar_t) * n + 16);
+	if (dirp->patt == NULL)
+		goto exit_closedir;
+
+	/*
+	 * Convert relative directory name to an absolute one.  This
+	 * allows rewinddir() to function correctly even when current
+	 * working directory is changed between opendir() and rewinddir().
+	 *
+	 * Note that on WinRT there's no way to convert relative paths
+	 * into absolute paths, so just assume it is an absolute path.
+	 */
+#if !defined(WINAPI_FAMILY_PARTITION) || WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+	/* Desktop */
+	n = GetFullPathNameW(dirname, n, dirp->patt, NULL);
+	if (n <= 0)
+		goto exit_closedir;
+#else
+	/* WinRT */
+	wcsncpy_s(dirp->patt, n+1, dirname, n);
+#endif
+
+	/* Append search pattern \* to the directory name */
+	p = dirp->patt + n;
+	switch (p[-1]) {
+	case '\\':
+	case '/':
+	case ':':
+		/* Directory ends in path separator, e.g. c:\temp\ */
+		/*NOP*/;
+		break;
+
+	default:
+		/* Directory name doesn't end in path separator */
+		*p++ = '\\';
+	}
+	*p++ = '*';
+	*p = '\0';
+
+	/* Open directory stream and retrieve the first entry */
+	if (!dirent_first(dirp))
+		goto exit_closedir;
+
+	/* Success */
+	return dirp;
+
+	/* Failure */
+exit_closedir:
+	_wclosedir(dirp);
+	return NULL;
+}
+
+/*
+ * Read next directory entry.
+ *
+ * Returns pointer to static directory entry which may be overwritten by
+ * subsequent calls to _wreaddir().
+ */
+static struct _wdirent *
+_wreaddir(_WDIR *dirp)
+{
+	/*
+	 * Read directory entry to buffer.  We can safely ignore the return
+	 * value as entry will be set to NULL in case of error.
+	 */
+	struct _wdirent *entry;
+	(void) _wreaddir_r(dirp, &dirp->ent, &entry);
+
+	/* Return pointer to statically allocated directory entry */
+	return entry;
+}
+
+/*
+ * Read next directory entry.
+ *
+ * Returns zero on success.  If end of directory stream is reached, then sets
+ * result to NULL and returns zero.
+ */
+static int
+_wreaddir_r(
+	_WDIR *dirp, struct _wdirent *entry, struct _wdirent **result)
+{
+	/* Validate directory handle */
+	if (!dirp || dirp->handle == INVALID_HANDLE_VALUE || !dirp->patt) {
+		dirent_set_errno(EBADF);
+		*result = NULL;
+		return -1;
+	}
+
+	/* Read next directory entry */
+	WIN32_FIND_DATAW *datap = dirent_next(dirp);
+	if (!datap) {
+		/* Return NULL to indicate end of directory */
+		*result = NULL;
+		return /*OK*/0;
+	}
+
+	/*
+	 * Copy file name as wide-character string.  If the file name is too
+	 * long to fit in to the destination buffer, then truncate file name
+	 * to PATH_MAX characters and zero-terminate the buffer.
+	 */
+	size_t i = 0;
+	while (i < PATH_MAX && datap->cFileName[i] != 0) {
+		entry->d_name[i] = datap->cFileName[i];
+		i++;
+	}
+	entry->d_name[i] = 0;
+
+	/* Length of file name excluding zero terminator */
+	entry->d_namlen = i;
+
+	/* Determine file type */
+	DWORD attr = datap->dwFileAttributes;
+	if ((attr & FILE_ATTRIBUTE_DEVICE) != 0)
+		entry->d_type = DT_CHR;
+	else if ((attr & FILE_ATTRIBUTE_REPARSE_POINT) != 0)
+		entry->d_type = DT_LNK;
+	else if ((attr & FILE_ATTRIBUTE_DIRECTORY) != 0)
+		entry->d_type = DT_DIR;
+	else
+		entry->d_type = DT_REG;
+
+	/* Read the next directory entry to cache */
+	datap = dirent_next(dirp);
+	if (datap) {
+		/* Compute 31-bit hash of the next directory entry */
+		entry->d_off = dirent_hash(datap);
+
+		/* Push the next directory entry back to cache */
+		dirp->cached = 1;
+	} else {
+		/* End of directory stream */
+		entry->d_off = (long) ((~0UL) >> 1);
+	}
+
+	/* Reset other fields */
+	entry->d_ino = 0;
+	entry->d_reclen = sizeof(struct _wdirent);
+
+	/* Set result address */
+	*result = entry;
+	return /*OK*/0;
+}
+
+/*
+ * Close directory stream opened by opendir() function.  This invalidates the
+ * DIR structure as well as any directory entry read previously by
+ * _wreaddir().
+ */
+static int
+_wclosedir(_WDIR *dirp)
+{
+	if (!dirp) {
+		dirent_set_errno(EBADF);
+		return /*failure*/-1;
+	}
+
+	/*
+	 * Release search handle if we have one.  Being able to handle
+	 * partially initialized _WDIR structure allows us to use this
+	 * function to handle errors occurring within _wopendir.
+	 */
+	if (dirp->handle != INVALID_HANDLE_VALUE) {
+		FindClose(dirp->handle);
+	}
+
+	/*
+	 * Release search pattern.  Note that we don't need to care if
+	 * dirp->patt is NULL or not: function free is guaranteed to act
+	 * appropriately.
+	 */
+	free(dirp->patt);
+
+	/* Release directory structure */
+	free(dirp);
+	return /*success*/0;
+}
+
+/*
+ * Rewind directory stream such that _wreaddir() returns the very first
+ * file name again.
+ */
+static void _wrewinddir(_WDIR* dirp)
+{
+	/* Check directory pointer */
+	if (!dirp || dirp->handle == INVALID_HANDLE_VALUE || !dirp->patt)
+		return;
+
+	/* Release existing search handle */
+	FindClose(dirp->handle);
+
+	/* Open new search handle */
+	dirent_first(dirp);
+}
+
+/* Get first directory entry */
+static WIN32_FIND_DATAW *
+dirent_first(_WDIR *dirp)
+{
+	/* Open directory and retrieve the first entry */
+	dirp->handle = FindFirstFileExW(
+		dirp->patt, FindExInfoStandard, &dirp->data,
+		FindExSearchNameMatch, NULL, 0);
+	if (dirp->handle == INVALID_HANDLE_VALUE)
+		goto error;
+
+	/* A directory entry is now waiting in memory */
+	dirp->cached = 1;
+	return &dirp->data;
+
+error:
+	/* Failed to open directory: no directory entry in memory */
+	dirp->cached = 0;
+	dirp->invalid = 1;
+
+	/* Set error code */
+	DWORD errorcode = GetLastError();
+	switch (errorcode) {
+	case ERROR_ACCESS_DENIED:
+		/* No read access to directory */
+		dirent_set_errno(EACCES);
+		break;
+
+	case ERROR_DIRECTORY:
+		/* Directory name is invalid */
+		dirent_set_errno(ENOTDIR);
+		break;
+
+	case ERROR_PATH_NOT_FOUND:
+	default:
+		/* Cannot find the file */
+		dirent_set_errno(ENOENT);
+	}
+	return NULL;
+}
+
+/* Get next directory entry */
+static WIN32_FIND_DATAW *
+dirent_next(_WDIR *dirp)
+{
+	/* Return NULL if seek position was invalid */
+	if (dirp->invalid)
+		return NULL;
+
+	/* Is the next directory entry already in cache? */
+	if (dirp->cached) {
+		/* Yes, a valid directory entry found in memory */
+		dirp->cached = 0;
+		return &dirp->data;
+	}
+
+	/* Read the next directory entry from stream */
+	if (FindNextFileW(dirp->handle, &dirp->data) == FALSE) {
+		/* End of directory stream */
+		return NULL;
+	}
+
+	/* Success */
+	return &dirp->data;
+}
+
+/*
+ * Compute 31-bit hash of file name.
+ *
+ * See djb2 at http://www.cse.yorku.ca/~oz/hash.html
+ */
+static long
+dirent_hash(WIN32_FIND_DATAW *datap)
+{
+	unsigned long hash = 5381;
+	unsigned long c;
+	const wchar_t *p = datap->cFileName;
+	const wchar_t *e = p + MAX_PATH;
+	while (p != e && (c = *p++) != 0) {
+		hash = (hash << 5) + hash + c;
+	}
+
+	return (long) (hash & ((~0UL) >> 1));
+}
+
+/* Open directory stream using plain old C-string */
+static DIR *opendir(const char *dirname)
+{
+	/* Must have directory name */
+	if (dirname == NULL || dirname[0] == '\0') {
+		dirent_set_errno(ENOENT);
+		return NULL;
+	}
+
+	/* Allocate memory for DIR structure */
+	struct DIR *dirp = (DIR*) malloc(sizeof(struct DIR));
+	if (!dirp)
+		return NULL;
+
+	/* Convert directory name to wide-character string */
+	wchar_t wname[PATH_MAX + 1];
+	size_t n;
+	int error = mbstowcs_s(&n, wname, PATH_MAX + 1, dirname, PATH_MAX+1);
+	if (error)
+		goto exit_failure;
+
+	/* Open directory stream using wide-character name */
+	dirp->wdirp = _wopendir(wname);
+	if (!dirp->wdirp)
+		goto exit_failure;
+
+	/* Success */
+	return dirp;
+
+	/* Failure */
+exit_failure:
+	free(dirp);
+	return NULL;
+}
+
+/* Read next directory entry */
+static struct dirent *
+readdir(DIR *dirp)
+{
+	/*
+	 * Read directory entry to buffer.  We can safely ignore the return
+	 * value as entry will be set to NULL in case of error.
+	 */
+	struct dirent *entry;
+	(void) readdir_r(dirp, &dirp->ent, &entry);
+
+	/* Return pointer to statically allocated directory entry */
+	return entry;
+}
+
+/*
+ * Read next directory entry into called-allocated buffer.
+ *
+ * Returns zero on success.  If the end of directory stream is reached, then
+ * sets result to NULL and returns zero.
+ */
+static int
+readdir_r(
+	DIR *dirp, struct dirent *entry, struct dirent **result)
+{
+	/* Read next directory entry */
+	WIN32_FIND_DATAW *datap = dirent_next(dirp->wdirp);
+	if (!datap) {
+		/* No more directory entries */
+		*result = NULL;
+		return /*OK*/0;
+	}
+
+	/* Attempt to convert file name to multi-byte string */
+	size_t n;
+	int error = wcstombs_s(
+		&n, entry->d_name, PATH_MAX + 1,
+		datap->cFileName, PATH_MAX + 1);
+
+	/*
+	 * If the file name cannot be represented by a multi-byte string, then
+	 * attempt to use old 8+3 file name.  This allows the program to
+	 * access files although file names may seem unfamiliar to the user.
+	 *
+	 * Be ware that the code below cannot come up with a short file name
+	 * unless the file system provides one.  At least VirtualBox shared
+	 * folders fail to do this.
+	 */
+	if (error && datap->cAlternateFileName[0] != '\0') {
+		error = wcstombs_s(
+			&n, entry->d_name, PATH_MAX + 1,
+			datap->cAlternateFileName, PATH_MAX + 1);
+	}
+
+	if (!error) {
+		/* Length of file name excluding zero terminator */
+		entry->d_namlen = n - 1;
+
+		/* Determine file type */
+		DWORD attr = datap->dwFileAttributes;
+		if ((attr & FILE_ATTRIBUTE_DEVICE) != 0)
+			entry->d_type = DT_CHR;
+		else if ((attr & FILE_ATTRIBUTE_REPARSE_POINT) != 0)
+			entry->d_type = DT_LNK;
+		else if ((attr & FILE_ATTRIBUTE_DIRECTORY) != 0)
+			entry->d_type = DT_DIR;
+		else
+			entry->d_type = DT_REG;
+
+		/* Get offset of next file */
+		datap = dirent_next(dirp->wdirp);
+		if (datap) {
+			/* Compute 31-bit hash of the next directory entry */
+			entry->d_off = dirent_hash(datap);
+
+			/* Push the next directory entry back to cache */
+			dirp->wdirp->cached = 1;
+		} else {
+			/* End of directory stream */
+			entry->d_off = (long) ((~0UL) >> 1);
+		}
+
+		/* Reset fields */
+		entry->d_ino = 0;
+		entry->d_reclen = sizeof(struct dirent);
+	} else {
+		/*
+		 * Cannot convert file name to multi-byte string so construct
+		 * an erroneous directory entry and return that.  Note that
+		 * we cannot return NULL as that would stop the processing
+		 * of directory entries completely.
+		 */
+		entry->d_name[0] = '?';
+		entry->d_name[1] = '\0';
+		entry->d_namlen = 1;
+		entry->d_type = DT_UNKNOWN;
+		entry->d_ino = 0;
+		entry->d_off = -1;
+		entry->d_reclen = 0;
+	}
+
+	/* Return pointer to directory entry */
+	*result = entry;
+	return /*OK*/0;
+}
+
+/* Close directory stream */
+static int
+closedir(DIR *dirp)
+{
+	int ok;
+
+	if (!dirp)
+		goto exit_failure;
+
+	/* Close wide-character directory stream */
+	ok = _wclosedir(dirp->wdirp);
+	dirp->wdirp = NULL;
+
+	/* Release multi-byte character version */
+	free(dirp);
+	return ok;
+
+exit_failure:
+	/* Invalid directory stream */
+	dirent_set_errno(EBADF);
+	return /*failure*/-1;
+}
+
+/* Rewind directory stream to beginning */
+static void
+rewinddir(DIR *dirp)
+{
+	if (!dirp)
+		return;
+
+	/* Rewind wide-character string directory stream */
+	_wrewinddir(dirp->wdirp);
+}
+
+/* Get position of directory stream */
+static long
+_wtelldir(_WDIR *dirp)
+{
+	if (!dirp || dirp->handle == INVALID_HANDLE_VALUE) {
+		dirent_set_errno(EBADF);
+		return /*failure*/-1;
+	}
+
+	/* Read next file entry */
+	WIN32_FIND_DATAW *datap = dirent_next(dirp);
+	if (!datap) {
+		/* End of directory stream */
+		return (long) ((~0UL) >> 1);
+	}
+
+	/* Store file entry to cache for readdir() */
+	dirp->cached = 1;
+
+	/* Return the 31-bit hash code to be used as stream position */
+	return dirent_hash(datap);
+}
+
+/* Get position of directory stream */
+static long
+telldir(DIR *dirp)
+{
+	if (!dirp) {
+		dirent_set_errno(EBADF);
+		return -1;
+	}
+
+	return _wtelldir(dirp->wdirp);
+}
+
+/* Seek directory stream to offset */
+static void
+_wseekdir(_WDIR *dirp, long loc)
+{
+	if (!dirp)
+		return;
+
+	/* Directory must be open */
+	if (dirp->handle == INVALID_HANDLE_VALUE)
+		goto exit_failure;
+
+	/* Ensure that seek position is valid */
+	if (loc < 0)
+		goto exit_failure;
+
+	/* Restart directory stream from the beginning */
+	FindClose(dirp->handle);
+	if (!dirent_first(dirp))
+		goto exit_failure;
+
+	/* Reset invalid flag so that we can read from the stream again */
+	dirp->invalid = 0;
+
+	/*
+	 * Read directory entries from the beginning until the hash matches a
+	 * file name.  Be ware that hash code is only 31 bits longs and
+	 * duplicates are possible: the hash code cannot return the position
+	 * with 100.00% accuracy! Moreover, the method is slow for large
+	 * directories.
+	 */
+	long hash;
+	do {
+		/* Read next directory entry */
+		WIN32_FIND_DATAW *datap = dirent_next(dirp);
+		if (!datap) {
+			/*
+			 * End of directory stream was reached before finding
+			 * the requested location.  Perhaps the file in
+			 * question was deleted or moved out of the directory.
+			 */
+			goto exit_failure;
+		}
+
+		/* Does the file name match the hash? */
+		hash = dirent_hash(datap);
+	} while (hash != loc);
+
+	/*
+	 * File name matches the hash!  Push the directory entry back to cache
+	 * from where next readdir() will return it.
+	 */
+	dirp->cached = 1;
+	dirp->invalid = 0;
+	return;
+
+exit_failure:
+	/* Ensure that readdir will return NULL */
+	dirp->invalid = 1;
+}
+
+/* Seek directory stream to offset */
+static void
+seekdir(DIR *dirp, long loc)
+{
+	if (!dirp)
+		return;
+
+	_wseekdir(dirp->wdirp, loc);
+}
+
+/* Scan directory for entries */
+static int
+scandir(
+	const char *dirname, struct dirent ***namelist,
+	int (*filter)(const struct dirent*),
+	int (*compare)(const struct dirent**, const struct dirent**))
+{
+	int result;
+
+	/* Open directory stream */
+	DIR *dir = opendir(dirname);
+	if (!dir) {
+		/* Cannot open directory */
+		return /*Error*/ -1;
+	}
+
+	/* Read directory entries to memory */
+	struct dirent *tmp = NULL;
+	struct dirent **files = NULL;
+	size_t size = 0;
+	size_t allocated = 0;
+	while (1) {
+		/* Allocate room for a temporary directory entry */
+		if (!tmp) {
+			tmp = (struct dirent*) malloc(sizeof(struct dirent));
+			if (!tmp)
+				goto exit_failure;
+		}
+
+		/* Read directory entry to temporary area */
+		struct dirent *entry;
+		if (readdir_r(dir, tmp, &entry) != /*OK*/0)
+			goto exit_failure;
+
+		/* Stop if we already read the last directory entry */
+		if (entry == NULL)
+			goto exit_success;
+
+		/* Determine whether to include the entry in results */
+		if (filter && !filter(tmp))
+			continue;
+
+		/* Enlarge pointer table to make room for another pointer */
+		if (size >= allocated) {
+			/* Compute number of entries in the new table */
+			size_t num_entries = size * 2 + 16;
+
+			/* Allocate new pointer table or enlarge existing */
+			void *p = realloc(files, sizeof(void*) * num_entries);
+			if (!p)
+				goto exit_failure;
+
+			/* Got the memory */
+			files = (dirent**) p;
+			allocated = num_entries;
+		}
+
+		/* Store the temporary entry to ptr table */
+		files[size++] = tmp;
+		tmp = NULL;
+	}
+
+exit_failure:
+	/* Release allocated entries */
+	for (size_t i = 0; i < size; i++) {
+		free(files[i]);
+	}
+
+	/* Release the pointer table */
+	free(files);
+	files = NULL;
+
+	/* Exit with error code */
+	result = /*error*/ -1;
+	goto exit_status;
+
+exit_success:
+	/* Sort directory entries */
+	if (size > 1 && compare) {
+		qsort(files, size, sizeof(void*),
+			(int (*) (const void*, const void*)) compare);
+	}
+
+	/* Pass pointer table to caller */
+	if (namelist)
+		*namelist = files;
+
+	/* Return the number of directory entries read */
+	result = (int) size;
+
+exit_status:
+	/* Release temporary directory entry, if we had one */
+	free(tmp);
+
+	/* Close directory stream */
+	closedir(dir);
+	return result;
+}
+
+/* Alphabetical sorting */
+static int
+alphasort(const struct dirent **a, const struct dirent **b)
+{
+	return strcoll((*a)->d_name, (*b)->d_name);
+}
+
+/* Sort versions */
+static int
+versionsort(const struct dirent **a, const struct dirent **b)
+{
+	return strverscmp((*a)->d_name, (*b)->d_name);
+}
+
+/* Compare strings */
+static int
+strverscmp(const char *a, const char *b)
+{
+	size_t i = 0;
+	size_t j;
+
+	/* Find first difference */
+	while (a[i] == b[i]) {
+		if (a[i] == '\0') {
+			/* No difference */
+			return 0;
+		}
+		++i;
+	}
+
+	/* Count backwards and find the leftmost digit */
+	j = i;
+	while (j > 0 && isdigit(a[j-1])) {
+		--j;
+	}
+
+	/* Determine mode of comparison */
+	if (a[j] == '0' || b[j] == '0') {
+		/* Find the next non-zero digit */
+		while (a[j] == '0' && a[j] == b[j]) {
+			j++;
+		}
+
+		/* String with more digits is smaller, e.g 002 < 01 */
+		if (isdigit(a[j])) {
+			if (!isdigit(b[j])) {
+				return -1;
+			}
+		} else if (isdigit(b[j])) {
+			return 1;
+		}
+	} else if (isdigit(a[j]) && isdigit(b[j])) {
+		/* Numeric comparison */
+		size_t k1 = j;
+		size_t k2 = j;
+
+		/* Compute number of digits in each string */
+		while (isdigit(a[k1])) {
+			k1++;
+		}
+		while (isdigit(b[k2])) {
+			k2++;
+		}
+
+		/* Number with more digits is bigger, e.g 999 < 1000 */
+		if (k1 < k2)
+			return -1;
+		else if (k1 > k2)
+			return 1;
+	}
+
+	/* Alphabetical comparison */
+	return (int) ((unsigned char) a[i]) - ((unsigned char) b[i]);
+}
+
+/* Convert multi-byte string to wide character string */
+#if !defined(_MSC_VER) || _MSC_VER < 1400
+static int
+dirent_mbstowcs_s(
+	size_t *pReturnValue, wchar_t *wcstr,
+	size_t sizeInWords, const char *mbstr, size_t count)
+{
+	/* Older Visual Studio or non-Microsoft compiler */
+	size_t n = mbstowcs(wcstr, mbstr, sizeInWords);
+	if (wcstr && n >= count)
+		return /*error*/ 1;
+
+	/* Zero-terminate output buffer */
+	if (wcstr && sizeInWords) {
+		if (n >= sizeInWords)
+			n = sizeInWords - 1;
+		wcstr[n] = 0;
+	}
+
+	/* Length of multi-byte string with zero terminator */
+	if (pReturnValue) {
+		*pReturnValue = n + 1;
+	}
+
+	/* Success */
+	return 0;
+}
+#endif
+
+/* Convert wide-character string to multi-byte string */
+#if !defined(_MSC_VER) || _MSC_VER < 1400
+static int
+dirent_wcstombs_s(
+	size_t *pReturnValue, char *mbstr,
+	size_t sizeInBytes, const wchar_t *wcstr, size_t count)
+{
+	/* Older Visual Studio or non-Microsoft compiler */
+	size_t n = wcstombs(mbstr, wcstr, sizeInBytes);
+	if (mbstr && n >= count)
+		return /*error*/1;
+
+	/* Zero-terminate output buffer */
+	if (mbstr && sizeInBytes) {
+		if (n >= sizeInBytes) {
+			n = sizeInBytes - 1;
+		}
+		mbstr[n] = '\0';
+	}
+
+	/* Length of resulting multi-bytes string WITH zero-terminator */
+	if (pReturnValue) {
+		*pReturnValue = n + 1;
+	}
+
+	/* Success */
+	return 0;
+}
+#endif
+
+/* Set errno variable */
+#if !defined(_MSC_VER) || _MSC_VER < 1400
+static void
+dirent_set_errno(int error)
+{
+	/* Non-Microsoft compiler or older Microsoft compiler */
+	errno = error;
+}
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+#endif /*DIRENT_H*/

--- a/src/win/wingetopt/LICENSE
+++ b/src/win/wingetopt/LICENSE
@@ -1,0 +1,54 @@
+#### AUTHORS:
+
+* Todd C. Miller <Todd.Miller@courtesan.com>
+* The NetBSD Foundation, Inc.
+* Alexei Kasatkin is the author of trivial CMakeLists.txt, build script itself is Public Domain
+
+#### LICENSE
+
+    Copyright (c) 2002 Todd C. Miller <Todd.Miller@courtesan.com>
+    
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+    
+    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+    
+    Sponsored in part by the Defense Advanced Research Projects
+    Agency (DARPA) and Air Force Research Laboratory, Air Force
+    Materiel Command, USAF, under agreement number F39502-99-1-0512.
+
+***
+
+    Copyright (c) 2000 The NetBSD Foundation, Inc.
+    All rights reserved.
+    
+    This code is derived from software contributed to The NetBSD Foundation
+    by Dieter Baron and Thomas Klausner.
+    
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+    
+    THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+    ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+    TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+    PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+    BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.

--- a/src/win/wingetopt/README.md
+++ b/src/win/wingetopt/README.md
@@ -1,0 +1,63 @@
+# wingetopt
+
+getopt library for Windows compilers
+
+
+This library was created to allow compilation linux-based software on Windows.
+http://en.wikipedia.org/wiki/Getopt
+
+The sources were taken from MinGW-runtime project.
+
+#### AUTHORS:
+
+* Todd C. Miller <Todd.Miller@courtesan.com>
+* The NetBSD Foundation, Inc.
+
+#### LICENSE
+
+    Copyright (c) 2002 Todd C. Miller <Todd.Miller@courtesan.com>
+    
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+    
+    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+    
+    Sponsored in part by the Defense Advanced Research Projects
+    Agency (DARPA) and Air Force Research Laboratory, Air Force
+    Materiel Command, USAF, under agreement number F39502-99-1-0512.
+
+***
+
+    Copyright (c) 2000 The NetBSD Foundation, Inc.
+    All rights reserved.
+    
+    This code is derived from software contributed to The NetBSD Foundation
+    by Dieter Baron and Thomas Klausner.
+    
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+    
+    THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+    ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+    TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+    PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+    BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.

--- a/src/win/wingetopt/getopt.c
+++ b/src/win/wingetopt/getopt.c
@@ -1,0 +1,562 @@
+/*	$OpenBSD: getopt_long.c,v 1.23 2007/10/31 12:34:57 chl Exp $	*/
+/*	$NetBSD: getopt_long.c,v 1.15 2002/01/31 22:43:40 tv Exp $	*/
+
+/*
+ * Copyright (c) 2002 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * Sponsored in part by the Defense Advanced Research Projects
+ * Agency (DARPA) and Air Force Research Laboratory, Air Force
+ * Materiel Command, USAF, under agreement number F39502-99-1-0512.
+ */
+/*-
+ * Copyright (c) 2000 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Dieter Baron and Thomas Klausner.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <getopt.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <windows.h>
+
+#define	REPLACE_GETOPT		/* use this getopt as the system getopt(3) */
+
+#ifdef REPLACE_GETOPT
+int	opterr = 1;		/* if error message should be printed */
+int	optind = 1;		/* index into parent argv vector */
+int	optopt = '?';		/* character checked for validity */
+#undef	optreset		/* see getopt.h */
+#define	optreset		__mingw_optreset
+int	optreset;		/* reset getopt */
+char    *optarg;		/* argument associated with option */
+#endif
+
+#define PRINT_ERROR	((opterr) && (*options != ':'))
+
+#define FLAG_PERMUTE	0x01	/* permute non-options to the end of argv */
+#define FLAG_ALLARGS	0x02	/* treat non-options as args to option "-1" */
+#define FLAG_LONGONLY	0x04	/* operate as getopt_long_only */
+
+/* return values */
+#define	BADCH		(int)'?'
+#define	BADARG		((*options == ':') ? (int)':' : (int)'?')
+#define	INORDER 	(int)1
+
+#ifndef __CYGWIN__
+#define __progname __argv[0]
+#else
+extern char __declspec(dllimport) *__progname;
+#endif
+
+#ifdef __CYGWIN__
+static char EMSG[] = "";
+#else
+#define	EMSG		""
+#endif
+
+static int getopt_internal(int, char * const *, const char *,
+			   const struct option *, int *, int);
+static int parse_long_options(char * const *, const char *,
+			      const struct option *, int *, int);
+static int gcd(int, int);
+static void permute_args(int, int, int, char * const *);
+
+static char *place = EMSG; /* option letter processing */
+
+/* XXX: set optreset to 1 rather than these two */
+static int nonopt_start = -1; /* first non option argument (for permute) */
+static int nonopt_end = -1;   /* first option after non options (for permute) */
+
+/* Error messages */
+static const char recargchar[] = "option requires an argument -- %c";
+static const char recargstring[] = "option requires an argument -- %s";
+static const char ambig[] = "ambiguous option -- %.*s";
+static const char noarg[] = "option doesn't take an argument -- %.*s";
+static const char illoptchar[] = "unknown option -- %c";
+static const char illoptstring[] = "unknown option -- %s";
+
+static void
+_vwarnx(const char *fmt,va_list ap)
+{
+  (void)fprintf(stderr,"%s: ",__progname);
+  if (fmt != NULL)
+    (void)vfprintf(stderr,fmt,ap);
+  (void)fprintf(stderr,"\n");
+}
+
+static void
+warnx(const char *fmt,...)
+{
+  va_list ap;
+  va_start(ap,fmt);
+  _vwarnx(fmt,ap);
+  va_end(ap);
+}
+
+/*
+ * Compute the greatest common divisor of a and b.
+ */
+static int
+gcd(int a, int b)
+{
+	int c;
+
+	c = a % b;
+	while (c != 0) {
+		a = b;
+		b = c;
+		c = a % b;
+	}
+
+	return (b);
+}
+
+/*
+ * Exchange the block from nonopt_start to nonopt_end with the block
+ * from nonopt_end to opt_end (keeping the same order of arguments
+ * in each block).
+ */
+static void
+permute_args(int panonopt_start, int panonopt_end, int opt_end,
+	char * const *nargv)
+{
+	int cstart, cyclelen, i, j, ncycle, nnonopts, nopts, pos;
+	char *swap;
+
+	/*
+	 * compute lengths of blocks and number and size of cycles
+	 */
+	nnonopts = panonopt_end - panonopt_start;
+	nopts = opt_end - panonopt_end;
+	ncycle = gcd(nnonopts, nopts);
+	cyclelen = (opt_end - panonopt_start) / ncycle;
+
+	for (i = 0; i < ncycle; i++) {
+		cstart = panonopt_end+i;
+		pos = cstart;
+		for (j = 0; j < cyclelen; j++) {
+			if (pos >= panonopt_end)
+				pos -= nnonopts;
+			else
+				pos += nopts;
+			swap = nargv[pos];
+			/* LINTED const cast */
+			((char **) nargv)[pos] = nargv[cstart];
+			/* LINTED const cast */
+			((char **)nargv)[cstart] = swap;
+		}
+	}
+}
+
+/*
+ * parse_long_options --
+ *	Parse long options in argc/argv argument vector.
+ * Returns -1 if short_too is set and the option does not match long_options.
+ */
+static int
+parse_long_options(char * const *nargv, const char *options,
+	const struct option *long_options, int *idx, int short_too)
+{
+	char *current_argv, *has_equal;
+	size_t current_argv_len;
+	int i, ambiguous, match;
+
+#define IDENTICAL_INTERPRETATION(_x, _y)                                \
+	(long_options[(_x)].has_arg == long_options[(_y)].has_arg &&    \
+	 long_options[(_x)].flag == long_options[(_y)].flag &&          \
+	 long_options[(_x)].val == long_options[(_y)].val)
+
+	current_argv = place;
+	match = -1;
+	ambiguous = 0;
+
+	optind++;
+
+	if ((has_equal = strchr(current_argv, '=')) != NULL) {
+		/* argument found (--option=arg) */
+		current_argv_len = has_equal - current_argv;
+		has_equal++;
+	} else
+		current_argv_len = strlen(current_argv);
+
+	for (i = 0; long_options[i].name; i++) {
+		/* find matching long option */
+		if (strncmp(current_argv, long_options[i].name,
+		    current_argv_len))
+			continue;
+
+		if (strlen(long_options[i].name) == current_argv_len) {
+			/* exact match */
+			match = i;
+			ambiguous = 0;
+			break;
+		}
+		/*
+		 * If this is a known short option, don't allow
+		 * a partial match of a single character.
+		 */
+		if (short_too && current_argv_len == 1)
+			continue;
+
+		if (match == -1)	/* partial match */
+			match = i;
+		else if (!IDENTICAL_INTERPRETATION(i, match))
+			ambiguous = 1;
+	}
+	if (ambiguous) {
+		/* ambiguous abbreviation */
+		if (PRINT_ERROR)
+			warnx(ambig, (int)current_argv_len,
+			     current_argv);
+		optopt = 0;
+		return (BADCH);
+	}
+	if (match != -1) {		/* option found */
+		if (long_options[match].has_arg == no_argument
+		    && has_equal) {
+			if (PRINT_ERROR)
+				warnx(noarg, (int)current_argv_len,
+				     current_argv);
+			/*
+			 * XXX: GNU sets optopt to val regardless of flag
+			 */
+			if (long_options[match].flag == NULL)
+				optopt = long_options[match].val;
+			else
+				optopt = 0;
+			return (BADARG);
+		}
+		if (long_options[match].has_arg == required_argument ||
+		    long_options[match].has_arg == optional_argument) {
+			if (has_equal)
+				optarg = has_equal;
+			else if (long_options[match].has_arg ==
+			    required_argument) {
+				/*
+				 * optional argument doesn't use next nargv
+				 */
+				optarg = nargv[optind++];
+			}
+		}
+		if ((long_options[match].has_arg == required_argument)
+		    && (optarg == NULL)) {
+			/*
+			 * Missing argument; leading ':' indicates no error
+			 * should be generated.
+			 */
+			if (PRINT_ERROR)
+				warnx(recargstring,
+				    current_argv);
+			/*
+			 * XXX: GNU sets optopt to val regardless of flag
+			 */
+			if (long_options[match].flag == NULL)
+				optopt = long_options[match].val;
+			else
+				optopt = 0;
+			--optind;
+			return (BADARG);
+		}
+	} else {			/* unknown option */
+		if (short_too) {
+			--optind;
+			return (-1);
+		}
+		if (PRINT_ERROR)
+			warnx(illoptstring, current_argv);
+		optopt = 0;
+		return (BADCH);
+	}
+	if (idx)
+		*idx = match;
+	if (long_options[match].flag) {
+		*long_options[match].flag = long_options[match].val;
+		return (0);
+	} else
+		return (long_options[match].val);
+#undef IDENTICAL_INTERPRETATION
+}
+
+/*
+ * getopt_internal --
+ *	Parse argc/argv argument vector.  Called by user level routines.
+ */
+static int
+getopt_internal(int nargc, char * const *nargv, const char *options,
+	const struct option *long_options, int *idx, int flags)
+{
+	const char *oli;				/* option letter list index */
+	int optchar, short_too;
+	static int posixly_correct = -1;
+
+	if (options == NULL)
+		return (-1);
+
+	/*
+	 * XXX Some GNU programs (like cvs) set optind to 0 instead of
+	 * XXX using optreset.  Work around this braindamage.
+	 */
+	if (optind == 0)
+		optind = optreset = 1;
+
+	/*
+	 * Disable GNU extensions if POSIXLY_CORRECT is set or options
+	 * string begins with a '+'.
+	 *
+	 * CV, 2009-12-14: Check POSIXLY_CORRECT anew if optind == 0 or
+	 *                 optreset != 0 for GNU compatibility.
+	 */
+	if (posixly_correct == -1 || optreset != 0)
+		posixly_correct = (getenv("POSIXLY_CORRECT") != NULL);
+	if (*options == '-')
+		flags |= FLAG_ALLARGS;
+	else if (posixly_correct || *options == '+')
+		flags &= ~FLAG_PERMUTE;
+	if (*options == '+' || *options == '-')
+		options++;
+
+	optarg = NULL;
+	if (optreset)
+		nonopt_start = nonopt_end = -1;
+start:
+	if (optreset || !*place) {		/* update scanning pointer */
+		optreset = 0;
+		if (optind >= nargc) {          /* end of argument vector */
+			place = EMSG;
+			if (nonopt_end != -1) {
+				/* do permutation, if we have to */
+				permute_args(nonopt_start, nonopt_end,
+				    optind, nargv);
+				optind -= nonopt_end - nonopt_start;
+			}
+			else if (nonopt_start != -1) {
+				/*
+				 * If we skipped non-options, set optind
+				 * to the first of them.
+				 */
+				optind = nonopt_start;
+			}
+			nonopt_start = nonopt_end = -1;
+			return (-1);
+		}
+		if (*(place = nargv[optind]) != '-' ||
+		    (place[1] == '\0' && strchr(options, '-') == NULL)) {
+			place = EMSG;		/* found non-option */
+			if (flags & FLAG_ALLARGS) {
+				/*
+				 * GNU extension:
+				 * return non-option as argument to option 1
+				 */
+				optarg = nargv[optind++];
+				return (INORDER);
+			}
+			if (!(flags & FLAG_PERMUTE)) {
+				/*
+				 * If no permutation wanted, stop parsing
+				 * at first non-option.
+				 */
+				return (-1);
+			}
+			/* do permutation */
+			if (nonopt_start == -1)
+				nonopt_start = optind;
+			else if (nonopt_end != -1) {
+				permute_args(nonopt_start, nonopt_end,
+				    optind, nargv);
+				nonopt_start = optind -
+				    (nonopt_end - nonopt_start);
+				nonopt_end = -1;
+			}
+			optind++;
+			/* process next argument */
+			goto start;
+		}
+		if (nonopt_start != -1 && nonopt_end == -1)
+			nonopt_end = optind;
+
+		/*
+		 * If we have "-" do nothing, if "--" we are done.
+		 */
+		if (place[1] != '\0' && *++place == '-' && place[1] == '\0') {
+			optind++;
+			place = EMSG;
+			/*
+			 * We found an option (--), so if we skipped
+			 * non-options, we have to permute.
+			 */
+			if (nonopt_end != -1) {
+				permute_args(nonopt_start, nonopt_end,
+				    optind, nargv);
+				optind -= nonopt_end - nonopt_start;
+			}
+			nonopt_start = nonopt_end = -1;
+			return (-1);
+		}
+	}
+
+	/*
+	 * Check long options if:
+	 *  1) we were passed some
+	 *  2) the arg is not just "-"
+	 *  3) either the arg starts with -- we are getopt_long_only()
+	 */
+	if (long_options != NULL && place != nargv[optind] &&
+	    (*place == '-' || (flags & FLAG_LONGONLY))) {
+		short_too = 0;
+		if (*place == '-')
+			place++;		/* --foo long option */
+		else if (*place != ':' && strchr(options, *place) != NULL)
+			short_too = 1;		/* could be short option too */
+
+		optchar = parse_long_options(nargv, options, long_options,
+		    idx, short_too);
+		if (optchar != -1) {
+			place = EMSG;
+			return (optchar);
+		}
+	}
+
+	if ((optchar = (int)*place++) == (int)':' ||
+	    (optchar == (int)'-' && *place != '\0') ||
+	    (oli = strchr(options, optchar)) == NULL) {
+		/*
+		 * If the user specified "-" and  '-' isn't listed in
+		 * options, return -1 (non-option) as per POSIX.
+		 * Otherwise, it is an unknown option character (or ':').
+		 */
+		if (optchar == (int)'-' && *place == '\0')
+			return (-1);
+		if (!*place)
+			++optind;
+		if (PRINT_ERROR)
+			warnx(illoptchar, optchar);
+		optopt = optchar;
+		return (BADCH);
+	}
+	if (long_options != NULL && optchar == 'W' && oli[1] == ';') {
+		/* -W long-option */
+		if (*place)			/* no space */
+			/* NOTHING */;
+		else if (++optind >= nargc) {	/* no arg */
+			place = EMSG;
+			if (PRINT_ERROR)
+				warnx(recargchar, optchar);
+			optopt = optchar;
+			return (BADARG);
+		} else				/* white space */
+			place = nargv[optind];
+		optchar = parse_long_options(nargv, options, long_options,
+		    idx, 0);
+		place = EMSG;
+		return (optchar);
+	}
+	if (*++oli != ':') {			/* doesn't take argument */
+		if (!*place)
+			++optind;
+	} else {				/* takes (optional) argument */
+		optarg = NULL;
+		if (*place)			/* no white space */
+			optarg = place;
+		else if (oli[1] != ':') {	/* arg not optional */
+			if (++optind >= nargc) {	/* no arg */
+				place = EMSG;
+				if (PRINT_ERROR)
+					warnx(recargchar, optchar);
+				optopt = optchar;
+				return (BADARG);
+			} else
+				optarg = nargv[optind];
+		}
+		place = EMSG;
+		++optind;
+	}
+	/* dump back option letter */
+	return (optchar);
+}
+
+#ifdef REPLACE_GETOPT
+/*
+ * getopt --
+ *	Parse argc/argv argument vector.
+ *
+ * [eventually this will replace the BSD getopt]
+ */
+int
+getopt(int nargc, char * const *nargv, const char *options)
+{
+
+	/*
+	 * We don't pass FLAG_PERMUTE to getopt_internal() since
+	 * the BSD getopt(3) (unlike GNU) has never done this.
+	 *
+	 * Furthermore, since many privileged programs call getopt()
+	 * before dropping privileges it makes sense to keep things
+	 * as simple (and bug-free) as possible.
+	 */
+	return (getopt_internal(nargc, nargv, options, NULL, NULL, 0));
+}
+#endif /* REPLACE_GETOPT */
+
+/*
+ * getopt_long --
+ *	Parse argc/argv argument vector.
+ */
+int
+getopt_long(int nargc, char * const *nargv, const char *options,
+    const struct option *long_options, int *idx)
+{
+
+	return (getopt_internal(nargc, nargv, options, long_options, idx,
+	    FLAG_PERMUTE));
+}
+
+/*
+ * getopt_long_only --
+ *	Parse argc/argv argument vector.
+ */
+int
+getopt_long_only(int nargc, char * const *nargv, const char *options,
+    const struct option *long_options, int *idx)
+{
+
+	return (getopt_internal(nargc, nargv, options, long_options, idx,
+	    FLAG_PERMUTE|FLAG_LONGONLY));
+}

--- a/src/win/wingetopt/getopt.h
+++ b/src/win/wingetopt/getopt.h
@@ -1,0 +1,105 @@
+#ifndef __GETOPT_H__
+/**
+ * DISCLAIMER
+ * This file has no copyright assigned and is placed in the Public Domain.
+ * This file is a part of the w64 mingw-runtime package.
+ *
+ * The w64 mingw-runtime package and its code is distributed in the hope that it 
+ * will be useful but WITHOUT ANY WARRANTY.  ALL WARRANTIES, EXPRESSED OR 
+ * IMPLIED ARE HEREBY DISCLAIMED.  This includes but is not limited to 
+ * warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#define __GETOPT_H__
+
+/* All the headers include this file. */
+#include <crtdefs.h>
+
+#if defined( WINGETOPT_SHARED_LIB )
+# if defined( BUILDING_WINGETOPT_DLL )
+#  define WINGETOPT_API __declspec(dllexport)
+# else
+#  define WINGETOPT_API __declspec(dllimport)
+# endif
+#else
+# define WINGETOPT_API
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+WINGETOPT_API extern int optind;		/* index of first non-option in argv      */
+WINGETOPT_API extern int optopt;		/* single option character, as parsed     */
+WINGETOPT_API extern int opterr;		/* flag to enable built-in diagnostics... */
+				/* (user may set to zero, to suppress)    */
+
+WINGETOPT_API extern char *optarg;		/* pointer to argument of current option  */
+
+extern int getopt(int nargc, char * const *nargv, const char *options);
+
+#ifdef _BSD_SOURCE
+/*
+ * BSD adds the non-standard `optreset' feature, for reinitialisation
+ * of `getopt' parsing.  We support this feature, for applications which
+ * proclaim their BSD heritage, before including this header; however,
+ * to maintain portability, developers are advised to avoid it.
+ */
+# define optreset  __mingw_optreset
+extern int optreset;
+#endif
+#ifdef __cplusplus
+}
+#endif
+/*
+ * POSIX requires the `getopt' API to be specified in `unistd.h';
+ * thus, `unistd.h' includes this header.  However, we do not want
+ * to expose the `getopt_long' or `getopt_long_only' APIs, when
+ * included in this manner.  Thus, close the standard __GETOPT_H__
+ * declarations block, and open an additional __GETOPT_LONG_H__
+ * specific block, only when *not* __UNISTD_H_SOURCED__, in which
+ * to declare the extended API.
+ */
+#endif /* !defined(__GETOPT_H__) */
+
+#if !defined(__UNISTD_H_SOURCED__) && !defined(__GETOPT_LONG_H__)
+#define __GETOPT_LONG_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct option		/* specification for a long form option...	*/
+{
+  const char *name;		/* option name, without leading hyphens */
+  int         has_arg;		/* does it take an argument?		*/
+  int        *flag;		/* where to save its status, or NULL	*/
+  int         val;		/* its associated status value		*/
+};
+
+enum    		/* permitted values for its `has_arg' field...	*/
+{
+  no_argument = 0,      	/* option never takes an argument	*/
+  required_argument,		/* option always requires an argument	*/
+  optional_argument		/* option may take an argument		*/
+};
+
+extern int getopt_long(int nargc, char * const *nargv, const char *options,
+    const struct option *long_options, int *idx);
+extern int getopt_long_only(int nargc, char * const *nargv, const char *options,
+    const struct option *long_options, int *idx);
+/*
+ * Previous MinGW implementation had...
+ */
+#ifndef HAVE_DECL_GETOPT
+/*
+ * ...for the long form API only; keep this for compatibility.
+ */
+# define HAVE_DECL_GETOPT	1
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !defined(__UNISTD_H_SOURCED__) && !defined(__GETOPT_LONG_H__) */

--- a/tests/pakka.bats
+++ b/tests/pakka.bats
@@ -14,7 +14,10 @@
 # setup_file) rather than pak0.pak directly.
 
 PROJECT_ROOT="${BATS_TEST_DIRNAME}/.."
-PAKKA="${PROJECT_ROOT}/pakka"
+# PAKKA can be pre-set by the caller (Windows CI points it at the MSVC
+# build's pakka.exe; the Makefile-driven path leaves it unset and we
+# fall through to the default location).
+PAKKA="${PAKKA:-${PROJECT_ROOT}/pakka}"
 PAK0="${PROJECT_ROOT}/build/test/pak0.pak"
 
 # Build a minimal valid pak with a single directory entry of the given
@@ -204,7 +207,9 @@ setup_file() {
 EOF
 )
 
-    [ "$output" = "$expected" ]
+    # Strip \r so MSVC-built pakka.exe (whose stdout is text-mode by
+    # default and emits CRLF) matches the same expected text as POSIX.
+    [ "${output//$'\r'/}" = "$expected" ]
 }
 
 @test "list --tree: empty pak prints root and zero summary" {
@@ -217,7 +222,7 @@ EOF
     [ "$status" -eq 0 ]
 
     expected=$(printf '.\n\n0 directories, 0 files')
-    [ "$output" = "$expected" ]
+    [ "${output//$'\r'/}" = "$expected" ]
 }
 
 @test "list --tree: rejected when combined with a non-list mode" {


### PR DESCRIPTION
Closes #1.

Adds a Windows / MSVC build of pakka, alongside the existing Makefile-driven Unix build. The hand-written Makefile stays as-is for POSIX; CMake is purely additive for the Windows path.

## How it's structured

- **`src/compat.{h,c}`** — a thin POSIX-on-Windows shim. On POSIX every `compat_*` function is a one-line forwarder; on Windows it routes to `_fullpath`, `_mkdir`, `_strdup`, `GetTempPathA`, `MoveFileExA`, etc. The rest of the codebase only ever names POSIX (or pakka-internal) primitives.
- **`src/win/`** — vendored polyfills, compiled only under `_WIN32`. wingetopt v1.00 (`alex85k/wingetopt` @ `effe6e2`, ISC) for `getopt()`; dirent 1.26 (`tronkko/dirent` @ `31db647`, MIT) for `opendir`/`readdir`. Both retain upstream LICENSE; `src/win/VENDOR.md` records pinned tags + commit SHAs for future bumps.
- **`CMakeLists.txt`** — minimal, lists the six `src/*.c` files plus `wingetopt/getopt.c` on `WIN32`. `/W4 /WX` mirrors the existing `WarningsAsErrors: '*'` policy in `.clang-tidy`; `_CRT_SECURE_NO_WARNINGS` + `_CRT_NONSTDC_NO_WARNINGS` silence C4996 deprecation spam on `fopen`/`strcpy`/`strtok`/`strdup`.
- **Windows CI job** (`windows-msvc-x86_64`) — `ilammy/msvc-dev-cmd` for `cl.exe`, `msys2/setup-msys2` for bash + bats + GNU make, `cmake -G Ninja` for the build, then `make fixture` + `bats tests/` against the cmake-built `pakka.exe`. Joins the existing 9-OS matrix.

## Two latent Windows bugs fixed while we're here

- **Rename-while-open.** The pak's `FILE*` was still open on the destination when both the create path (`close_pakfile`) and the delete path (`delete_entries`) called `rename`. POSIX allows this; Windows refuses because CRT `fopen` omits `FILE_SHARE_DELETE`. Both call sites now `fclose(fp)` first, then call `compat_rename_replace` (which is `MoveFileExA(... REPLACE_EXISTING)` on Windows, plain `rename` on POSIX). `close_pakfile` tolerates `fp == NULL` so the delete path can null it out after closing.
- **fopen binary modes.** Every pak/payload open is now `"rb"`/`"wb"`/`"r+b"`. On POSIX the `b` is a no-op; on Windows it prevents text-mode `\n`↔`\r\n` translation silently corrupting extracted `.pak`/`.mdl`/`.bsp`/`.wav` files.

## Test plan
- [x] **macOS Apple Silicon / Intel:** `make && make test && make lint` all green (no regression — the compat layer is pure passthrough on POSIX, the `b` flag is a no-op).
- [x] **macOS CMake build:** `cmake -B build/cmake -S . && cmake --build build/cmake`, then `PAKKA=$PWD/build/cmake/pakka bats tests/` — all 23 tests pass against the cmake-built binary.
- [x] **actionlint + zizmor** clean on the new workflow job.
- [x] **Codex review** (2 high + 2 medium findings flagged, all addressed before commit).
- [x] **Windows CI:** first run will exercise `cl.exe` + the rename-while-open fix on a real Windows host. This is the test that proves the port works.

## Deferred to follow-ups
Three runtime gaps identified during planning are intentionally not in this PR:
- Case-insensitive collisions on extract (NTFS lower-cases `PROGS.DAT` and `progs.dat` to the same file)
- Windows reserved names (`CON`, `NUL.txt`, trailing `.` / ` `)
- Static path buffer ceilings beyond `_MAX_PATH`

None block a first Windows release; the security-relevant path-traversal hardening was already taken care of in #2.

## Vendored code attribution
- `src/win/wingetopt/` — © Todd C. Miller / NetBSD Foundation, ISC license
- `src/win/dirent/` — © Toni Rönkkö, MIT license